### PR TITLE
refactor: keep cohort links non-nullable; document config via JSON Schema

### DIFF
--- a/assets/cohort-configs/bitcoin-protocol-development.json
+++ b/assets/cohort-configs/bitcoin-protocol-development.json
@@ -6,6 +6,17 @@
   "weeks": [
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Bitcoin Node Interaction and OP_RETURN Transaction",
+        "concepts": "RPC interface, wallet management, block mining, transaction construction, OP_RETURN outputs, fee rates",
+        "problem": "Connect to a Bitcoin Core node running in regtest mode using RPC. Create and load a wallet named \"testwallet\", generate an address from it, and mine blocks to that address until you have a spendable balance. Then construct and broadcast a transaction that sends 100 BTC to the address bcrt1qq2yshcmzdlznnpxx258xswqlmqcxjs4dssfxt2 and includes a second OP_RETURN output containing the binary encoding of the message \"We are all Satoshi!!\". Set the fee rate to exactly 21 sats/vB.",
+        "expectedOutput": [
+          "A running regtest Bitcoin node with a funded \"testwallet\" wallet",
+          "A broadcast transaction containing two outputs: a 100 BTC payment output and an OP_RETURN data output with the message \"We are all Satoshi!!\"",
+          "A fee rate of exactly 21 sats/vB on the transaction",
+          "The transaction ID (txid) written to out.txt"
+        ]
+      },
       "title": "Bitcoin Protocol Development Cohort",
       "readingMaterial": [
         { "label": "Welcome to the Bitcoin Protocol Development Seminar", "url": "https://chaincode.gitbook.io/seminars/bitcoin-protocol-development/welcome-to-the-bitcoin-protocol" }
@@ -38,6 +49,17 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Building a P2SH-P2WSH Multisig Transaction",
+        "concepts": "P2SH wrapping, P2WSH, 2-of-2 multisig, sighash calculation, ECDSA signatures, scriptSig and witness construction",
+        "problem": "Construct a signed P2SH-P2WSH transaction that spends a 2-of-2 multisig redeem script. You are given two private keys and the redeem script (OP_2 <pubkey1> <pubkey2> OP_2 OP_CHECKMULTISIG). The transaction must contain exactly one input (outpoint hash of all zeros, index 0, sequence 0xffffffff) and exactly one output paying 0.001 BTC to the address 325UUecEQuyrTd28Xs2hvAxdAjHM7XzqVF, with locktime 0. Calculate the sighash of the unsigned transaction, compute ECDSA signatures with both private keys, construct the correct scriptSig from the redeem script, and build a valid multisig witness stack.",
+        "expectedOutput": [
+          "A correctly computed sighash for the P2SH-P2WSH input",
+          "Valid ECDSA signatures from both private keys",
+          "A correct scriptSig wrapping the witness program and a valid witness stack passing 2-of-2 multisig validation",
+          "The fully serialized transaction hex written to out.txt"
+        ]
+      },
       "title": "SEGWIT",
       "readingMaterial": [
         { "label": "SEGWIT", "url": "https://chaincode.gitbook.io/seminars/bitcoin-protocol-development/segwit" }
@@ -69,6 +91,16 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Mine Your First Block",
+        "concepts": "Transaction validation, mempool processing, coinbase transactions, merkle root, block header construction, proof-of-work",
+        "problem": "Simulate the mining process of a block. You are given a mempool folder containing JSON files, each representing an individual transaction with all of its data. Write a script that processes these transactions, validates them, selects valid ones for inclusion, constructs a coinbase transaction, and mines a block whose hash meets the difficulty target 0000ffff00000000000000000000000000000000000000000000000000000000. Any previous block hash may be used as long as the mined block hash satisfies the target.",
+        "expectedOutput": [
+          "A valid block header whose hash is below the difficulty target",
+          "A correctly serialized coinbase transaction",
+          "An out.txt file containing the block header on the first line, the serialized coinbase transaction on the second line, and the txids of all mined transactions on the following lines, starting with the coinbase txid"
+        ]
+      },
       "title": "Mining and Network Block Propagation",
       "readingMaterial": [
         { "label": "Mining and Network Block Propagation", "url": "https://chaincode.gitbook.io/seminars/bitcoin-protocol-development/mining-network-prop" }
@@ -100,6 +132,16 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Connecting to the P2P Network",
+        "concepts": "P2P protocol, version/verack handshake, network message serialization, block retrieval, block parsing, fee and coinbase analysis",
+        "problem": "Interact directly with the Bitcoin P2P network without using RPC. Discover and connect to a Bitcoin node, perform the initial version/verack handshake to establish a valid connection, then request the full block data for block height 840000 using its block hash (obtained from a public blockchain explorer). Parse the raw block to extract the 80-byte block header, the block hash, the total fees collected by the miner, and information identifying the miner from the coinbase transaction.",
+        "expectedOutput": [
+          "A successful version/verack handshake with a Bitcoin node",
+          "Retrieved and parsed raw block data for block 840000",
+          "An out.txt file containing the block header on the first line, the block hash on the second line, the total fees collected in sats on the third line, and the miner information on the fourth line"
+        ]
+      },
       "title": "P2P",
       "readingMaterial": [
         { "label": "P2P", "url": "https://chaincode.gitbook.io/seminars/bitcoin-protocol-development/p2p" }
@@ -122,6 +164,17 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Parsing a Descriptor and Calculating Wallet Balance",
+        "concepts": "Output descriptors, extended public keys, address derivation, gap limit handling, Esplora API, balance calculation",
+        "problem": "Parse the output descriptor wpkh(tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp/*)#adv567t2 to derive wallet addresses. Continue generating addresses until a sequence of 10 consecutive unused addresses (addresses with no transactions) is detected. For each generated address, fetch its transaction data from a locally running Esplora API (http://localhost:8094/regtest/api/) and calculate the total balance across all addresses.",
+        "expectedOutput": [
+          "Addresses correctly derived from the wpkh descriptor",
+          "Address scanning that stops after detecting a gap of 10 consecutive unused addresses",
+          "Transaction data fetched from the Esplora API for each address",
+          "An out.txt file containing a single line with the total balance in BTC"
+        ]
+      },
       "title": "Scripts and Wallets",
       "readingMaterial": [
         { "label": "Scripts and Wallets", "url": "https://chaincode.gitbook.io/seminars/bitcoin-protocol-development/script-wallets" }

--- a/assets/cohort-configs/bitcoin-protocol-development.json
+++ b/assets/cohort-configs/bitcoin-protocol-development.json
@@ -1,10 +1,7 @@
 {
   "gdSessions": 5,
   "classroomId": "255956",
-  "links": [
-    { "label": "Wheel of Names", "url": "https://wheelofnames.com/", "minRole": "TEACHING_ASSISTANT" },
-    { "label": "MultiBuzz", "url": "https://www.multibuzz.app/", "minRole": "TEACHING_ASSISTANT" }
-  ],
+  "links": [],
   "weeks": [
     {
       "hasExercise": true,

--- a/assets/cohort-configs/bitcoin-protocol-development.json
+++ b/assets/cohort-configs/bitcoin-protocol-development.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./cohort-config.schema.json",
   "gdSessions": 5,
   "classroomId": "255956",
   "links": [],

--- a/assets/cohort-configs/cohort-config.schema.json
+++ b/assets/cohort-configs/cohort-config.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bitshala.org/schemas/cohort-config.schema.json",
+  "title": "Cohort Config",
+  "description": "Configuration for a single cohort, loaded and validated at startup by CohortsConfigService. The file name must match the CohortType (lower-cased, underscores -> hyphens). Global links shared by every cohort (Wheel of Names, MultiBuzz) are added in code and need not be listed here.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["gdSessions", "weeks", "links"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Editor tooling only. Points at this schema for autocomplete + inline docs; stripped before validation."
+    },
+    "gdSessions": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 8,
+      "description": "Number of group-discussion sessions. Must equal the length of `weeks`."
+    },
+    "classroomId": {
+      "type": "string",
+      "pattern": "^[0-9]+$",
+      "description": "GitHub Classroom id used to sync exercise scores. Required when any week has `hasExercise: true`; may be omitted otherwise."
+    },
+    "links": {
+      "type": "array",
+      "description": "Course-specific links for this cohort. Use [] when there are none. Global links shared by every cohort are merged in by CohortsConfigService at load time, so do not list them here.",
+      "items": { "$ref": "#/$defs/link" }
+    },
+    "weeks": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "description": "One entry per group-discussion session. Length must equal `gdSessions`.",
+      "items": { "$ref": "#/$defs/week" }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "type": "object",
+        "properties": {
+          "weeks": {
+            "type": "array",
+            "contains": {
+              "type": "object",
+              "properties": { "hasExercise": { "const": true } },
+              "required": ["hasExercise"]
+            }
+          }
+        },
+        "required": ["weeks"]
+      },
+      "then": { "required": ["classroomId"] }
+    }
+  ],
+  "$defs": {
+    "week": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hasExercise",
+        "questions",
+        "bonusQuestions",
+        "title",
+        "readingMaterial"
+      ],
+      "properties": {
+        "hasExercise": {
+          "type": "boolean",
+          "description": "Whether this week has a graded exercise (scored via GitHub Classroom). When true, `exercise` content is required and the cohort must declare `classroomId`."
+        },
+        "questions": {
+          "type": "array",
+          "description": "Discussion questions for the week.",
+          "items": { "$ref": "#/$defs/question" }
+        },
+        "bonusQuestions": {
+          "type": "array",
+          "description": "Optional-to-answer bonus discussion questions.",
+          "items": { "$ref": "#/$defs/question" }
+        },
+        "title": {
+          "type": "string",
+          "description": "Week title."
+        },
+        "readingMaterial": {
+          "type": "array",
+          "description": "Reading-material links for the week.",
+          "items": { "$ref": "#/$defs/readingMaterial" }
+        },
+        "activity": {
+          "type": "string",
+          "description": "Optional free-text activity for the week. Omit when there is none."
+        },
+        "exercise": {
+          "$ref": "#/$defs/exercise",
+          "description": "Exercise content. Required when `hasExercise` is true; omit otherwise."
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "type": "object",
+            "properties": { "hasExercise": { "const": true } },
+            "required": ["hasExercise"]
+          },
+          "then": { "required": ["exercise"] }
+        }
+      ]
+    },
+    "question": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "Question prompt."
+        },
+        "attachments": {
+          "type": "array",
+          "description": "Optional file names, relative to the cohort's attachments directory (assets/cohort-configs/attachments/<cohort>/). Each file must exist on disk. Omit when the question has no attachments.",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "readingMaterial": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "url"],
+      "properties": {
+        "label": { "type": "string", "description": "Display label." },
+        "url": { "type": "string", "description": "Link URL." }
+      }
+    },
+    "exercise": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "concepts", "problem", "expectedOutput"],
+      "properties": {
+        "title": { "type": "string", "description": "Exercise title." },
+        "concepts": {
+          "type": "string",
+          "description": "Concepts the exercise covers."
+        },
+        "problem": {
+          "type": "string",
+          "description": "Problem statement."
+        },
+        "expectedOutput": {
+          "type": "array",
+          "description": "Expected output lines.",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "url"],
+      "properties": {
+        "label": { "type": "string", "description": "Display label." },
+        "url": { "type": "string", "description": "Link URL." },
+        "minRole": {
+          "type": "string",
+          "enum": ["ADMIN", "TEACHING_ASSISTANT", "STUDENT"],
+          "description": "Minimum role required to see this link. Absent => visible to everyone."
+        }
+      }
+    }
+  }
+}

--- a/assets/cohort-configs/learning-bitcoin-from-command-line.json
+++ b/assets/cohort-configs/learning-bitcoin-from-command-line.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./cohort-config.schema.json",
   "gdSessions": 6,
   "classroomId": "234007",
   "links": [

--- a/assets/cohort-configs/learning-bitcoin-from-command-line.json
+++ b/assets/cohort-configs/learning-bitcoin-from-command-line.json
@@ -10,6 +10,17 @@
   "weeks": [
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Setting Up and Interacting with a Bitcoin Node",
+        "concepts": "Node setup, bitcoin.conf configuration, RPC interaction, wallet creation, block rewards, coinbase maturity, transaction lifecycle",
+        "problem": "Set up Bitcoin Core from scratch: download the binaries, install them, create a bitcoin.conf configured for regtest (with server, txindex, and rpcauth settings), and start bitcoind. Then create two wallets named \"Miner\" and \"Trader\". Generate an address labeled \"Mining Reward\" from the Miner wallet and mine blocks to it until the wallet shows a positive balance, observing how many blocks it takes and why (coinbase maturity). Send 20 BTC from Miner to a Trader address labeled \"Received\", inspect the unconfirmed transaction in the node's mempool using getmempoolentry, then confirm it by mining one block.",
+        "expectedOutput": [
+          "A running regtest Bitcoin node with two wallets: Miner and Trader",
+          "A comment explaining why block rewards require 100 blocks of maturity before they are spendable",
+          "A mempool entry fetched for the unconfirmed transaction",
+          "An out.txt file with the txid, Miner's input address and amount, Trader's output address and amount, Miner's change address and amount, transaction fee, and the block height and block hash where the transaction confirmed"
+        ]
+      },
       "title": "Bitcoin Fundamentals & Cryptographic Primitives",
       "readingMaterial": [
         { "label": "Chapter 1: Introducing Bitcoin", "url": "https://github.com/BlockchainCommons/Learning-Bitcoin-from-the-Command-Line/blob/master/01_0_Introduction.md" },
@@ -40,6 +51,17 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Fee Bumping with RBF and CPFP",
+        "concepts": "Replace-By-Fee (RBF), Child-Pays-For-Parent (CPFP), mempool inspection, transaction conflicts, fee management",
+        "problem": "Create and fund Miner and Trader wallets with at least 3 block rewards (150 BTC). Craft an RBF-enabled \"Parent\" transaction spending two 50 BTC block rewards, paying 70 BTC to Trader and 29.99999 BTC change back to Miner. Broadcast it but do not mine it. Query the mempool for its details and record them to parent.json. Then create a \"Child\" (CPFP) transaction spending Miner's change output of the Parent, paying 29.99998 BTC to a new Miner address, and record it to child.json. Finally, fee-bump the Parent via RBF by hand-crafting a conflicting transaction with the same inputs but a fee raised by 10,000 satoshis (without using bumpfee), broadcast it, and record it to parent-rbf.json. Observe what happens to the Child transaction after the replacement.",
+        "expectedOutput": [
+          "Three JSON files (parent.json, child.json, parent-rbf.json), each containing txid, inputs, outputs, fee, and weight",
+          "A broadcast RBF-signaled Parent transaction and a Child transaction spending its change output",
+          "A hand-crafted replacement transaction that successfully evicts the original Parent and the Child from the mempool",
+          "A demonstration of why RBF and CPFP cannot safely be combined on the same parent transaction"
+        ]
+      },
       "title": "Transactions, Fees & Advanced Transaction Mechanics",
       "readingMaterial": [
         { "label": "Chapter 4: Sending Bitcoin Transactions", "url": "https://github.com/BlockchainCommons/Learning-Bitcoin-from-the-Command-Line/blob/master/04_0_Sending_Bitcoin_Transactions.md" },
@@ -67,6 +89,17 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "2-of-2 Multisig with PSBT",
+        "concepts": "Multisig scripts, P2WSH addresses, PSBT workflow, collaborative signing, joint custody",
+        "problem": "Simulate a 2-of-2 multisig share transfer between two participants, Alice and Bob. Create three wallets (Miner, Alice, Bob), fund Miner with block rewards, and send 15 BTC each to Alice and Bob. Fetch Alice's and Bob's public keys and construct a 2-of-2 P2WSH multisig address. Build a funding PSBT that deposits 20 BTC into the multisig (10 BTC from each party with correct change back to each), sign it with both parties, broadcast, and mine 6 blocks to confirm. Then build a spending PSBT that spends the multisig UTXO and splits the funds back equally (10 BTC each, minus fees), sign it in turn with Alice and Bob, extract and broadcast the final transaction, and mine 6 blocks to confirm.",
+        "expectedOutput": [
+          "A 2-of-2 P2WSH multisig address built from Alice's and Bob's public keys",
+          "A confirmed funding transaction depositing 20 BTC into the multisig (10 BTC from each party)",
+          "A confirmed spending transaction signed by both parties that splits the funds back equally",
+          "Balance reports for Alice and Bob after each phase, and an out.txt containing the funding txid and spending txid on separate lines"
+        ]
+      },
       "title": "Multisig, PSBT & Hardware Wallet Integration",
       "readingMaterial": [
         { "label": "Chapter 6: Expanding Bitcoin Transactions with Multisigs", "url": "https://github.com/BlockchainCommons/Learning-Bitcoin-from-the-Command-Line/blob/master/06_0_Expanding_Bitcoin_Transactions_Multisigs.md" },
@@ -90,6 +123,17 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Absolute Timelocks and OP_RETURN",
+        "concepts": "Absolute timelocks (nLockTime), block height locks, non-final transactions, OP_RETURN data embedding",
+        "problem": "Simulate a timelocked salary payment. Create three wallets (Miner, Employee, Employer) and fund the Employer from mined blocks. Create a salary transaction of 40 BTC from Employer to Employee with an absolute timelock of block 500, so it cannot be included in the blockchain until block 500 is mined. Attempt to broadcast it early and report what happens. Mine up to block 500 and broadcast the transaction. Then have the Employee spend the funds to a new Employee address, adding an OP_RETURN output containing the ASCII string \"I got my salary, I am rich\". Broadcast and confirm the spending transaction.",
+        "expectedOutput": [
+          "A timelocked transaction that is rejected as non-final when broadcast before block 500, with a comment reporting the observed error",
+          "Successful broadcast of the salary transaction after mining to block 500",
+          "A confirmed spending transaction containing an OP_RETURN output with the message \"I got my salary, I am rich\"",
+          "Final balances of Employee and Employer, and an out.txt containing the funding txid and spending txid on separate lines"
+        ]
+      },
       "title": "Bitcoin Script & Transaction Verification",
       "readingMaterial": [
         { "label": "Chapter 8: Expanding Bitcoin Transactions in Other Ways", "url": "https://github.com/BlockchainCommons/Learning-Bitcoin-from-the-Command-Line/blob/master/08_0_Expanding_Bitcoin_Transactions_Other.md" },
@@ -114,6 +158,17 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Relative Timelocks",
+        "concepts": "Relative timelocks, nSequence, BIP68, input aging, refund transactions",
+        "problem": "Demonstrate a relative timelock spend. Create two wallets (Miner and Alice), fund Alice by mining blocks to Miner and sending coins to Alice, then confirm the funding and assert Alice has a positive balance. Build a refund transaction where Alice pays 10 BTC back to Miner with a relative timelock of 10 blocks (by setting the input's nSequence appropriately). Attempt to broadcast the refund transaction immediately and report the error you observe. Mine 10 more blocks, broadcast the refund transaction successfully, and mine one additional block to confirm it.",
+        "expectedOutput": [
+          "A refund transaction with nSequence set for a 10-block relative timelock",
+          "A report of the non-BIP68-final error observed when broadcasting before the input has aged 10 blocks",
+          "Successful broadcast and confirmation of the refund transaction after mining 10 blocks",
+          "Alice's final balance reported, and an out.txt containing the refund txid"
+        ]
+      },
       "title": "Advanced Scripts & Time Locks",
       "readingMaterial": [
         { "label": "Chapter 10: Embedding Bitcoin Scripts in P2SH Transactions", "url": "https://github.com/BlockchainCommons/Learning-Bitcoin-from-the-Command-Line/blob/master/10_0_Embedding_Bitcoin_Scripts_in_P2SH_Transactions.md" },

--- a/assets/cohort-configs/learning-bitcoin-from-command-line.json
+++ b/assets/cohort-configs/learning-bitcoin-from-command-line.json
@@ -2,8 +2,6 @@
   "gdSessions": 6,
   "classroomId": "234007",
   "links": [
-    { "label": "Wheel of Names", "url": "https://wheelofnames.com/", "minRole": "TEACHING_ASSISTANT" },
-    { "label": "MultiBuzz", "url": "https://www.multibuzz.app/", "minRole": "TEACHING_ASSISTANT" },
     { "label": "lbtcl-playbook", "url": "https://docs.google.com/document/d/1YXsW3gRVbBxBEAAcI84W3KCFBbevzVXUUznH8w2XohM/preview", "minRole": "TEACHING_ASSISTANT" },
     { "label": "lbtcl-bonus-questions", "url": "https://gist.github.com/rajarshimaitra/f83eaf3295b88ac180a965b3daab4d8a", "minRole": "TEACHING_ASSISTANT" },
     { "label": "lbtcl-main-repo", "url": "https://github.com/Bitshala/LBTCL", "minRole": "TEACHING_ASSISTANT" }

--- a/assets/cohort-configs/mastering-bitcoin.json
+++ b/assets/cohort-configs/mastering-bitcoin.json
@@ -1,9 +1,6 @@
 {
   "gdSessions": 8,
-  "links": [
-    { "label": "Wheel of Names", "url": "https://wheelofnames.com/", "minRole": "TEACHING_ASSISTANT" },
-    { "label": "MultiBuzz", "url": "https://www.multibuzz.app/", "minRole": "TEACHING_ASSISTANT" }
-  ],
+  "links": [],
   "weeks": [
     {
       "hasExercise": false,

--- a/assets/cohort-configs/mastering-bitcoin.json
+++ b/assets/cohort-configs/mastering-bitcoin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./cohort-config.schema.json",
   "gdSessions": 8,
   "links": [],
   "weeks": [

--- a/assets/cohort-configs/mastering-lightning-network.json
+++ b/assets/cohort-configs/mastering-lightning-network.json
@@ -1,10 +1,7 @@
 {
   "gdSessions": 8,
   "classroomId": "300036",
-  "links": [
-    { "label": "Wheel of Names", "url": "https://wheelofnames.com/", "minRole": "TEACHING_ASSISTANT" },
-    { "label": "MultiBuzz", "url": "https://www.multibuzz.app/", "minRole": "TEACHING_ASSISTANT" }
-  ],
+  "links": [],
   "weeks": [
     {
       "hasExercise": true,

--- a/assets/cohort-configs/mastering-lightning-network.json
+++ b/assets/cohort-configs/mastering-lightning-network.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./cohort-config.schema.json",
   "gdSessions": 8,
   "classroomId": "300036",
   "links": [],

--- a/assets/cohort-configs/programming-bitcoin.json
+++ b/assets/cohort-configs/programming-bitcoin.json
@@ -1,10 +1,7 @@
 {
   "gdSessions": 7,
   "classroomId": "243620",
-  "links": [
-    { "label": "Wheel of Names", "url": "https://wheelofnames.com/", "minRole": "TEACHING_ASSISTANT" },
-    { "label": "MultiBuzz", "url": "https://www.multibuzz.app/", "minRole": "TEACHING_ASSISTANT" }
-  ],
+  "links": [],
   "weeks": [
     {
       "hasExercise": true,

--- a/assets/cohort-configs/programming-bitcoin.json
+++ b/assets/cohort-configs/programming-bitcoin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./cohort-config.schema.json",
   "gdSessions": 7,
   "classroomId": "243620",
   "links": [],

--- a/assets/cohort-configs/programming-bitcoin.json
+++ b/assets/cohort-configs/programming-bitcoin.json
@@ -6,6 +6,16 @@
   "weeks": [
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Finite Fields and Elliptic Curves",
+        "concepts": "Finite field arithmetic, modular arithmetic, Fermat's little theorem, elliptic curve point addition",
+        "problem": "Implement the mathematical building blocks of Bitcoin's cryptography in Python. Build a FieldElement class supporting addition, subtraction, multiplication, exponentiation, and division over a finite field using modular arithmetic (using Fermat's little theorem for division). Then build a Point class representing points on an elliptic curve y² = x³ + ax + b, implementing point addition for all cases: the point at infinity (identity), additive inverses, points with different x coordinates, and point doubling. Complete all exercises in Chapter1.ipynb and Chapter2.ipynb.",
+        "expectedOutput": [
+          "A working FieldElement class with all arithmetic operations defined over a prime field",
+          "A Point class that correctly validates curve membership and handles all point addition cases including identity and doubling",
+          "All cells in Chapter1.ipynb and Chapter2.ipynb running without errors"
+        ]
+      },
       "title": "Finite Fields & Elliptic Curves",
       "readingMaterial": [
         { "label": "Chapter 1: Finite Fields", "url": "https://github.com/jimmysong/programmingbitcoin/blob/master/ch01.asciidoc" },
@@ -28,6 +38,17 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Elliptic Curve Cryptography",
+        "concepts": "Elliptic curves over finite fields, scalar multiplication, secp256k1, public/private key pairs, ECDSA signing and verification",
+        "problem": "Combine finite fields and elliptic curves to build working elliptic curve cryptography. Implement curve points over a finite field and scalar multiplication using binary expansion. Define the secp256k1 curve parameters used by Bitcoin (S256Field, S256Point, the generator point G, and the group order N). Then implement Signature and PrivateKey classes to perform ECDSA: derive a public key from a private key, sign a message hash, and verify a signature. Complete all exercises in Chapter3.ipynb.",
+        "expectedOutput": [
+          "Elliptic curve point operations working over a finite field, including efficient scalar multiplication",
+          "A working secp256k1 implementation with the correct generator point and group order",
+          "ECDSA signature creation and verification that round-trips correctly",
+          "All cells in Chapter3.ipynb running without errors"
+        ]
+      },
       "title": "Elliptic Curve Cryptography",
       "readingMaterial": [
         { "label": "Chapter 3: Elliptic Curve Cryptography", "url": "https://github.com/jimmysong/programmingbitcoin/blob/master/ch03.asciidoc" }
@@ -50,6 +71,17 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Serialization and Transactions",
+        "concepts": "SEC public key format, DER signatures, Base58Check, WIF, varints, transaction parsing and serialization, fee calculation",
+        "problem": "Implement Bitcoin's serialization formats and transaction structure. Serialize public keys in compressed and uncompressed SEC format, encode signatures in DER format, and implement Base58Check encoding to produce Bitcoin addresses and WIF-encoded private keys. Then build a transaction parser and serializer that handles the version, inputs (previous txid, index, scriptSig, sequence), outputs (amount, scriptPubKey), locktime, and varints, and calculate the fee of a transaction by looking up the value of its inputs. Complete all exercises in Chapter4.ipynb and Chapter5.ipynb.",
+        "expectedOutput": [
+          "SEC and DER serialization for public keys and signatures",
+          "Correct Bitcoin addresses (Base58Check) and WIF private keys derived from key material",
+          "A transaction parser that can parse and re-serialize raw transactions losslessly",
+          "Correct fee calculation for a parsed transaction, and all cells in Chapter4.ipynb and Chapter5.ipynb running without errors"
+        ]
+      },
       "title": "Serialization & Transactions",
       "readingMaterial": [
         { "label": "Chapter 4: Serialization", "url": "https://github.com/jimmysong/programmingbitcoin/blob/master/ch04.asciidoc" },
@@ -75,6 +107,17 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Script and Transaction Validation",
+        "concepts": "Bitcoin Script, opcode evaluation, p2pk and p2pkh, sighash computation, transaction validation, transaction creation",
+        "problem": "Implement Bitcoin's Script language and use it to validate and create transactions. Build a Script parser, serializer, and evaluation engine that executes the combined scriptSig and scriptPubKey using a stack, supporting standard patterns like p2pkh. Implement the SIGHASH_ALL signature hash computation, validate a transaction by verifying the signatures on each of its inputs, and then construct, sign, and serialize your own transaction. Complete all exercises in Chapter6.ipynb and Chapter7.ipynb.",
+        "expectedOutput": [
+          "A Script evaluation engine that correctly executes p2pkh scripts",
+          "Correct sighash (z) computation for transaction inputs",
+          "Full transaction validation that verifies input signatures",
+          "A self-created, signed transaction that serializes correctly, and all cells in Chapter6.ipynb and Chapter7.ipynb running without errors"
+        ]
+      },
       "title": "Script & Transaction Creation",
       "readingMaterial": [
         { "label": "Chapter 6: Script", "url": "https://github.com/jimmysong/programmingbitcoin/blob/master/ch06.asciidoc" },
@@ -97,6 +140,17 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Pay-to-Script-Hash (P2SH)",
+        "concepts": "P2SH addresses, redeem scripts, bare multisig, OP_CHECKMULTISIG, p2sh signature validation",
+        "problem": "Implement Pay-to-Script-Hash, the mechanism that enables complex spending conditions like multisig behind a short address. Implement OP_CHECKMULTISIG (handling its off-by-one bug), construct redeem scripts for multisig, hash them to produce P2SH addresses, and extend Script evaluation to detect the special p2sh pattern and execute the redeem script. Finally, modify the sighash computation for p2sh inputs and verify a signature on a p2sh multisig transaction input. Complete all exercises in Chapter8.ipynb.",
+        "expectedOutput": [
+          "A working OP_CHECKMULTISIG implementation that validates bare multisig scripts",
+          "P2SH address generation from a redeem script hash",
+          "Script evaluation that recognizes and correctly executes the p2sh pattern",
+          "Signature verification for a p2sh multisig input, and all cells in Chapter8.ipynb running without errors"
+        ]
+      },
       "title": "P2SH & Segwit",
       "readingMaterial": [
         { "label": "Chapter 8: P2SH", "url": "https://github.com/jimmysong/programmingbitcoin/blob/master/ch08.asciidoc" },
@@ -123,6 +177,17 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "Blocks and Networking",
+        "concepts": "Block headers, coinbase transactions, difficulty and target, proof-of-work validation, P2P network messages, version/verack handshake",
+        "problem": "Implement Bitcoin's block structure and connect to the peer-to-peer network. Parse and serialize 80-byte block headers, identify coinbase transactions and extract block height from the coinbase scriptSig, compute the block hash and validate proof-of-work against the target, and calculate difficulty and the new bits after a difficulty adjustment period. Then implement the network layer: parse and serialize network envelopes, construct version and verack messages, perform the network handshake with a peer, and download block headers from the network. Complete all exercises in Chapter9.ipynb and Chapter10.ipynb.",
+        "expectedOutput": [
+          "Block header parsing, serialization, and proof-of-work validation",
+          "Correct target, difficulty, and new-bits calculation after a 2016-block adjustment period",
+          "A completed version/verack handshake with a live Bitcoin node",
+          "Block headers downloaded and validated from a peer, and all cells in Chapter9.ipynb and Chapter10.ipynb running without errors"
+        ]
+      },
       "title": "Blocks & Networking",
       "readingMaterial": [
         { "label": "Chapter 9: Blocks", "url": "https://github.com/jimmysong/programmingbitcoin/blob/master/ch09.asciidoc" },
@@ -150,6 +215,17 @@
     },
     {
       "hasExercise": true,
+      "exercise": {
+        "title": "SPV and Bloom Filters",
+        "concepts": "Merkle trees, merkle proofs, simplified payment verification, bloom filters, merkleblock messages",
+        "problem": "Implement Simplified Payment Verification, allowing a light client to verify transaction inclusion without downloading full blocks. Build merkle parent and merkle root computation, construct a full merkle tree, and parse merkleblock messages to verify a merkle inclusion proof from the flag bits and hashes. Then implement BIP37 bloom filters: compute filter bits using murmur3 hashing, load a filter to a connected node with the filterload command, request merkle blocks with getdata, and identify transactions of interest belonging to an address. Complete all exercises in Chapter11.ipynb and Chapter12.ipynb.",
+        "expectedOutput": [
+          "Correct merkle root computation from a list of transaction hashes",
+          "Merkleblock parsing and validation of merkle inclusion proofs",
+          "A working BIP37 bloom filter that a node accepts via filterload",
+          "Transactions of interest discovered from a peer using bloom-filtered merkle blocks, and all cells in Chapter11.ipynb and Chapter12.ipynb running without errors"
+        ]
+      },
       "title": "SPV & Bloom Filters",
       "readingMaterial": [
         { "label": "Chapter 11: SPV", "url": "https://github.com/jimmysong/programmingbitcoin/blob/master/ch11.asciidoc" },

--- a/src/cohorts/cohorts.config.model.ts
+++ b/src/cohorts/cohorts.config.model.ts
@@ -116,6 +116,9 @@ export class CohortConfig {
     )
     classroomId!: string;
 
+    // Course-specific links for this cohort. Use [] if there are none.
+    // Global links shared by every cohort (e.g. Wheel of Names, MultiBuzz) are
+    // defined once in CohortsConfigService and merged in at load time.
     @IsArray()
     @ValidateNested({ each: true })
     @Type(() => LinkConfig)

--- a/src/cohorts/cohorts.config.model.ts
+++ b/src/cohorts/cohorts.config.model.ts
@@ -3,6 +3,7 @@ import {
     ArrayMinSize,
     IsArray,
     IsBoolean,
+    IsDefined,
     IsEnum,
     IsInt,
     IsNumberString,
@@ -20,6 +21,9 @@ export class QuestionConfig {
     @IsString()
     text!: string;
 
+    // Optional file names, relative to the cohort's attachments directory
+    // (assets/cohort-configs/attachments/<cohort>/). Each must exist on disk.
+    // Omit when the question has no attachments.
     @IsOptional()
     @IsArray()
     @IsString({ each: true })
@@ -71,11 +75,16 @@ export class CohortWeekConfig {
     @Type(() => ReadingMaterialConfig)
     readingMaterial!: ReadingMaterialConfig[];
 
+    // Optional free-text activity for the week. Omit when there is none.
     @IsOptional()
     @IsString()
     activity?: string;
 
-    @IsOptional()
+    // Exercise content. Required when `hasExercise` is true; omit otherwise.
+    // (When `hasExercise` is false but an exercise is present, it is still
+    // validated.)
+    @ValidateIf((o: CohortWeekConfig) => o.hasExercise || o.exercise != null)
+    @IsDefined()
     @ValidateNested()
     @Type(() => ExerciseConfig)
     exercise?: ExerciseConfig;

--- a/src/cohorts/cohorts.config.service.ts
+++ b/src/cohorts/cohorts.config.service.ts
@@ -1,11 +1,30 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { CohortType } from '@/common/enum';
+import { CohortType, UserRole } from '@/common/enum';
 import { join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { validateSync } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { CohortConfig, QuestionConfig } from '@/cohorts/cohorts.config.model';
+import {
+    CohortConfig,
+    LinkConfig,
+    QuestionConfig,
+} from '@/cohorts/cohorts.config.model';
 import { ServiceError } from '@/common/errors';
+
+// Links shared by every cohort, declared once here so they aren't duplicated
+// across each cohort config file. Merged into every cohort at load time.
+const GLOBAL_LINKS: LinkConfig[] = [
+    {
+        label: 'Wheel of Names',
+        url: 'https://wheelofnames.com/',
+        minRole: UserRole.TEACHING_ASSISTANT,
+    },
+    {
+        label: 'MultiBuzz',
+        url: 'https://www.multibuzz.app/',
+        minRole: UserRole.TEACHING_ASSISTANT,
+    },
+];
 
 @Injectable()
 export class CohortsConfigService implements OnModuleInit {
@@ -67,6 +86,16 @@ export class CohortsConfigService implements OnModuleInit {
                     }
                 }
             }
+
+            // Prepend shared global links, then this cohort's course-specific
+            // links, de-duplicated by url so a config can't reintroduce a
+            // global one.
+            const seen = new Set<string>();
+            config.links = [...GLOBAL_LINKS, ...config.links].filter((link) => {
+                if (seen.has(link.url)) return false;
+                seen.add(link.url);
+                return true;
+            });
 
             this.configs.set(type, config);
             this.logger.log(`Loaded config for ${type} (${fileName})`);

--- a/src/cohorts/cohorts.config.service.ts
+++ b/src/cohorts/cohorts.config.service.ts
@@ -47,7 +47,13 @@ export class CohortsConfigService implements OnModuleInit {
                 );
             }
 
-            const config = plainToInstance(CohortConfig, JSON.parse(raw));
+            const parsed = JSON.parse(raw) as Record<string, unknown>;
+            // `$schema` references cohort-config.schema.json for editor tooling
+            // (autocomplete + inline docs); it is not part of the validated
+            // model, so drop it before `forbidNonWhitelisted` would reject it.
+            delete parsed['$schema'];
+
+            const config = plainToInstance(CohortConfig, parsed);
             const errors = validateSync(config, {
                 whitelist: true,
                 forbidNonWhitelisted: true,


### PR DESCRIPTION
## Summary

Reworks how shared cohort links are handled and makes the cohort config format self-documenting, without leaving any config field silently nullable/undiscoverable.

### 1. Keep `links` required; merge global links in code
The two links shared by every cohort (Wheel of Names, MultiBuzz) were duplicated across every config file. They're now declared **once** as a `GLOBAL_LINKS` constant in `CohortsConfigService` and merged into each cohort at load time (de-duped by url).

`CohortConfig.links` stays a **required, non-nullable `LinkConfig[]`** — so there are no `?? []` fallbacks leaking through consumers, and every config file visibly carries a `links` array (`[]` when there are none). The option is discoverable instead of hidden behind an optional field.

### 2. Make optional config fields discoverable via JSON Schema
The remaining optional fields (`attachments`, `activity`, `minRole`) are intentionally **kept optional** — their absence is semantically meaningful and forcing them would add large noise (e.g. `attachments` is used by ~0.9% of questions). Instead of hiding them, discoverability is solved with documentation:

- New `assets/cohort-configs/cohort-config.schema.json` (draft 2020-12) describing every field with inline descriptions, `additionalProperties: false` (mirroring `forbidNonWhitelisted`), and conditional rules.
- Each config references it via `"$schema": "./cohort-config.schema.json"` → editor autocomplete + inline docs.
- The loader strips `$schema` before validation so it isn't rejected by `forbidNonWhitelisted` (keeps the model class clean).
- Doc comments added to the optional model fields.

### 3. Require `exercise` when `hasExercise` is true
`exercise` content was optional even on weeks flagged `hasExercise: true`. It's now conditionally required via `@ValidateIf` + `@IsDefined()` (mirroring the existing `classroomId` rule), and still validated when present on a non-exercise week.

The exercise content for the 17 affected weeks (`bitcoin-protocol-development` ×5, `learning-bitcoin-from-command-line` ×5, `programming-bitcoin` ×7) is included in this PR, so all five cohort configs validate and the app boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)