### PR TITLE
feat: add portfolio and linkedin profile links to user profile

### DIFF
--- a/migrations/1780719477000-migrations.ts
+++ b/migrations/1780719477000-migrations.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migrations1780719477000 implements MigrationInterface {
+    name = 'Migrations1780719477000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "user" ADD "portfolioUrl" character varying(2048)`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "user" ADD "linkedinProfileUrl" character varying(2048)`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "user" DROP COLUMN "linkedinProfileUrl"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "user" DROP COLUMN "portfolioUrl"`,
+        );
+    }
+}

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -43,6 +43,12 @@ export class User extends BaseEntity {
     @Column('varchar', { length: 2048, nullable: true })
     githubProfileUrl!: string | null;
 
+    @Column('varchar', { length: 2048, nullable: true })
+    portfolioUrl!: string | null;
+
+    @Column('varchar', { length: 2048, nullable: true })
+    linkedinProfileUrl!: string | null;
+
     @Column({ type: 'jsonb', default: [] })
     skills!: string[];
 

--- a/src/users/users.request.ts
+++ b/src/users/users.request.ts
@@ -46,6 +46,18 @@ export class UpdateUserRequest {
     @MaxLength(2048)
     githubProfileUrl?: string;
 
+    /** Portfolio or side-project URL */
+    @IsOptional()
+    @IsUrl({ require_protocol: true })
+    @MaxLength(2048)
+    portfolioUrl?: string;
+
+    /** LinkedIn profile URL */
+    @IsOptional()
+    @IsUrl({ require_protocol: true })
+    @MaxLength(2048)
+    linkedinProfileUrl?: string;
+
     /** Skills */
     @IsOptional()
     @IsArray()

--- a/src/users/users.response.ts
+++ b/src/users/users.response.ts
@@ -11,6 +11,8 @@ export class GetUserResponse {
     description: string | null;
     background: string | null;
     githubProfileUrl: string | null;
+    portfolioUrl: string | null;
+    linkedinProfileUrl: string | null;
     skills: string[] | null;
     // ISO date (YYYY-MM-DD) of when first heard about Bitcoin
     firstHeardAboutBitcoinOn: string | null;
@@ -35,6 +37,8 @@ export class GetUserResponse {
             description: user.description,
             background: user.background,
             githubProfileUrl: user.githubProfileUrl,
+            portfolioUrl: user.portfolioUrl,
+            linkedinProfileUrl: user.linkedinProfileUrl,
             skills: user.skills,
             firstHeardAboutBitcoinOn: user.firstHeardAboutBitcoinOn,
             bitcoinBooksRead: user.bitcoinBooksRead,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -141,6 +141,12 @@ export class UsersService {
         if (body.githubProfileUrl !== undefined) {
             user.githubProfileUrl = body.githubProfileUrl;
         }
+        if (body.portfolioUrl !== undefined) {
+            user.portfolioUrl = body.portfolioUrl;
+        }
+        if (body.linkedinProfileUrl !== undefined) {
+            user.linkedinProfileUrl = body.linkedinProfileUrl;
+        }
         if (body.skills !== undefined) {
             user.skills = body.skills ?? [];
         }


### PR DESCRIPTION
Add optional portfolioUrl and linkedinProfileUrl fields alongside the existing githubProfileUrl on the user profile. Both are nullable, single URLs validated with protocol (max 2048 chars) and editable via PATCH /users/me. Includes the corresponding migration.