### PR TITLE
feat: accept certificate name on fellowship application (write-through to user.name)

### DIFF
--- a/src/fellowship-applications/fellowship-applications.request.dto.ts
+++ b/src/fellowship-applications/fellowship-applications.request.dto.ts
@@ -203,6 +203,15 @@ export class ProposalFieldsDto {
     @IsString()
     @MaxLength(255)
     location?: string;
+
+    // Profile field: the applicant's name used on the certificate. Written
+    // through to `user.name` rather than stored on the application (see
+    // service), so it is never duplicated. Mirrors `location`.
+    @IsOptional()
+    @Transform(trim)
+    @IsString()
+    @MaxLength(255)
+    name?: string;
 }
 
 export class CreateFellowshipApplicationRequestDto extends ProposalFieldsDto {

--- a/src/fellowship-applications/fellowship-applications.service.ts
+++ b/src/fellowship-applications/fellowship-applications.service.ts
@@ -83,6 +83,10 @@ export class FellowshipApplicationsService {
             user.location = emptyToNull(dto.location);
             changed = true;
         }
+        if (dto.name !== undefined) {
+            user.name = emptyToNull(dto.name);
+            changed = true;
+        }
         if (dto.github !== undefined) {
             const handle = emptyToNull(dto.github);
             user.githubProfileUrl = handle


### PR DESCRIPTION
## Summary

Adds the applicant's **certificate name** to the fellowship application flow, wired the same way `location` already works — submitted in the proposal payload and **written through to the user profile** rather than stored on the application.

Per review, the certificate name reuses the existing **`user.name`** profile field, so **no new column, migration, or DTO field** is introduced.

## Changes

- **`fellowship-applications.request.dto.ts`** — add optional `name` to `ProposalFieldsDto` (accepted on `POST /fellowship-applications` and `PATCH /fellowship-applications/{id}`), mirroring `location`: `@IsOptional @Transform(trim) @IsString @MaxLength(255)`.
- **`fellowship-applications.service.ts`** — in `applyProfileFields`, write `name` through to `user.name` via `emptyToNull`: trimmed, empty-string clears, omitted key leaves it untouched. Not stored on the application.

## Behavior (matches `location`)

| Concern | Behavior |
|---|---|
| Accepted on proposal create/update | in write body |
| Persistence | Written through to `user.name`; not stored on the application |
| Returned by proposal GET | omitted (unchanged) |
| Returned by `GET /users/me` | via existing `name` field (used for prefill) |

## Frontend follow-up

The frontend must send/read **`name`** (not `certificateName`) in the proposal body and prefill from `GET /users/me` -> `name`.

## Testing

- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)