### PR TITLE
Cross Cohort Performance metrics

### DIFF
--- a/src/scores/scores.controller.ts
+++ b/src/scores/scores.controller.ts
@@ -1,4 +1,5 @@
 import {
+    applyDecorators,
     Body,
     Controller,
     Get,
@@ -9,9 +10,17 @@ import {
     UsePipes,
     ValidationPipe,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+    ApiBearerAuth,
+    ApiExtraModels,
+    ApiOkResponse,
+    ApiOperation,
+    ApiTags,
+    getSchemaPath,
+} from '@nestjs/swagger';
 import { ScoresService } from '@/scores/scores.service';
 import {
+    CrossCohortPerformanceEntryDto,
     GetUsersScoresResponseDto,
     LeaderboardEntryDto,
     ListScoresForCohortAndWeekResponseDto,
@@ -25,6 +34,22 @@ import {
 } from '@/scores/scores.request.dto';
 import { GetUser } from '@/decorators/user.decorator';
 import { User } from '@/entities/user.entity';
+
+function ApiCrossCohortPerformanceResponse() {
+    return applyDecorators(
+        ApiExtraModels(CrossCohortPerformanceEntryDto),
+        ApiOkResponse({
+            description:
+                'Map of "<cohortType>_S<season>" to { scoreReceived, maxScore, attendedWeeks, totalWeeks }',
+            schema: {
+                type: 'object',
+                additionalProperties: {
+                    $ref: getSchemaPath(CrossCohortPerformanceEntryDto),
+                },
+            },
+        }),
+    );
+}
 
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 @ApiTags('Scores')
@@ -95,6 +120,31 @@ export class ScoresController {
         @Param('userId', new ParseUUIDPipe()) userId: string,
     ): Promise<GetUsersScoresResponseDto> {
         return this.scoresService.getUserScores(userId);
+    }
+
+    @Get('me/cross-cohort-performance')
+    @ApiOperation({
+        summary:
+            "Get the authenticated user's score received vs total score per cohort",
+    })
+    @ApiCrossCohortPerformanceResponse()
+    @Roles(UserRole.STUDENT, UserRole.TEACHING_ASSISTANT, UserRole.ADMIN)
+    async getMyCrossCohortPerformance(
+        @GetUser() user: User,
+    ): Promise<Record<string, CrossCohortPerformanceEntryDto>> {
+        return this.scoresService.getCrossCohortPerformance(user.id);
+    }
+
+    @Get('user/:userId/cross-cohort-performance')
+    @ApiOperation({
+        summary: "Get a user's score received vs total score per cohort",
+    })
+    @ApiCrossCohortPerformanceResponse()
+    @Roles(UserRole.TEACHING_ASSISTANT, UserRole.ADMIN)
+    async getUserCrossCohortPerformance(
+        @Param('userId', new ParseUUIDPipe()) userId: string,
+    ): Promise<Record<string, CrossCohortPerformanceEntryDto>> {
+        return this.scoresService.getCrossCohortPerformance(userId);
     }
 
     @Post('week/:weekId/assign-groups')

--- a/src/scores/scores.response.dto.ts
+++ b/src/scores/scores.response.dto.ts
@@ -325,6 +325,11 @@ export class GetCohortScoresResponseDto {
     weeklyScores!: WeeklyScore[];
     totalScore!: number;
     maxTotalScore!: number;
+    attendedWeeks!: number;
+    totalWeeks!: number; // weeks with an attendance record (same set as weeklyScores)
+    scorePercent!: number; // round(totalScore / maxTotalScore * 100), 0 if maxTotalScore is 0
+    attendancePercent!: number; // round(attendedWeeks / totalWeeks * 100), 0 if totalWeeks is 0
+    avgScore!: number; // totalScore / totalWeeks, 0 if totalWeeks is 0
 
     constructor(partial: GetCohortScoresResponseDto) {
         Object.assign(this, partial);
@@ -337,6 +342,17 @@ export class GetUsersScoresResponseDto {
     maxTotalScore!: number;
 
     constructor(partial: GetUsersScoresResponseDto) {
+        Object.assign(this, partial);
+    }
+}
+
+export class CrossCohortPerformanceEntryDto {
+    scoreReceived!: number;
+    maxScore!: number;
+    attendedWeeks!: number;
+    totalWeeks!: number;
+
+    constructor(partial: CrossCohortPerformanceEntryDto) {
         Object.assign(this, partial);
     }
 }

--- a/src/scores/scores.service.ts
+++ b/src/scores/scores.service.ts
@@ -6,6 +6,7 @@ import { Repository } from 'typeorm';
 import { ExerciseScore } from '@/entities/exercise-score.entity';
 import { User } from '@/entities/user.entity';
 import {
+    CrossCohortPerformanceEntryDto,
     GetCohortScoresResponseDto,
     GetUsersScoresResponseDto,
     LeaderboardEntryDto,
@@ -302,6 +303,11 @@ export class ScoresService {
                 }
             }
 
+            // Only weeks with attendance records, so attendancePercent and
+            // avgScore share scorePercent's denominator (same set as weeklyScores)
+            const totalWeeks = weeklyScores.length;
+            const attendedWeeks = weeklyScores.filter((w) => w.attended).length;
+
             cohortScore.push(
                 new GetCohortScoresResponseDto({
                     cohortId: cohort.id,
@@ -310,6 +316,21 @@ export class ScoresService {
                     weeklyScores: weeklyScores,
                     totalScore: cohortTotalScore,
                     maxTotalScore: cohortMaxTotalScore,
+                    attendedWeeks: attendedWeeks,
+                    totalWeeks: totalWeeks,
+                    scorePercent:
+                        cohortMaxTotalScore === 0
+                            ? 0
+                            : Math.round(
+                                  (cohortTotalScore / cohortMaxTotalScore) *
+                                      100,
+                              ),
+                    attendancePercent:
+                        totalWeeks === 0
+                            ? 0
+                            : Math.round((attendedWeeks / totalWeeks) * 100),
+                    avgScore:
+                        totalWeeks === 0 ? 0 : cohortTotalScore / totalWeeks,
                 }),
             );
 
@@ -322,6 +343,24 @@ export class ScoresService {
             totalScore: totalScore,
             maxTotalScore: maxTotalScore,
         });
+    }
+
+    async getCrossCohortPerformance(
+        userId: string,
+    ): Promise<Record<string, CrossCohortPerformanceEntryDto>> {
+        const { cohorts } = await this.getUserScores(userId);
+
+        return Object.fromEntries(
+            cohorts.map((c) => [
+                `${c.cohortType}_S${c.seasonNumber}`,
+                new CrossCohortPerformanceEntryDto({
+                    scoreReceived: c.totalScore,
+                    maxScore: c.maxTotalScore,
+                    attendedWeeks: c.attendedWeeks,
+                    totalWeeks: c.totalWeeks,
+                }),
+            ]),
+        );
     }
 
     async assignGroupsForCohortWeek(


### PR DESCRIPTION
## Summary
- Adds `attendedWeeks`, `totalWeeks`, `scorePercent`, `attendancePercent`, `avgScore` to `GetCohortScoresResponseDto`
- Computed per-cohort inside the existing loop in `ScoresService.getUserScores` (backs `GET /scores/me` and `GET /scores/user/:userId`), no schema/migration changes
- Enables cross-cohort performance comparisons per user without the client recomputing percentages

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Manually hit `GET /scores/me` for a user in multiple cohorts and confirm the new fields, including zero-denominator cohorts (no weeks / no scored weeks yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)