### PR TITLE
feat: internal admin notes on fellowship reports

### DIFF
--- a/migrations/1786349505574-migrations.ts
+++ b/migrations/1786349505574-migrations.ts
@@ -5,22 +5,22 @@ export class Migrations1786349505574 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            `CREATE TABLE "fellowship_report_note" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "body" text NOT NULL, "reportId" uuid, "authorId" uuid, CONSTRAINT "PK_fellowship_report_note" PRIMARY KEY ("id"))`,
+            `CREATE TABLE "fellowship_report_note" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "body" text NOT NULL, "reportId" uuid, "authorId" uuid, CONSTRAINT "PK_9c4fd7c8d184cb074597bddb015" PRIMARY KEY ("id"))`,
         );
         await queryRunner.query(
-            `ALTER TABLE "fellowship_report_note" ADD CONSTRAINT "FK_fellowship_report_note_report" FOREIGN KEY ("reportId") REFERENCES "fellowship_report"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+            `ALTER TABLE "fellowship_report_note" ADD CONSTRAINT "FK_1a587c4a095b42730afc09c125d" FOREIGN KEY ("reportId") REFERENCES "fellowship_report"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
         );
         await queryRunner.query(
-            `ALTER TABLE "fellowship_report_note" ADD CONSTRAINT "FK_fellowship_report_note_author" FOREIGN KEY ("authorId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+            `ALTER TABLE "fellowship_report_note" ADD CONSTRAINT "FK_56c8dcb3be26c0a1b19e4fdac57" FOREIGN KEY ("authorId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
         );
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            `ALTER TABLE "fellowship_report_note" DROP CONSTRAINT "FK_fellowship_report_note_author"`,
+            `ALTER TABLE "fellowship_report_note" DROP CONSTRAINT "FK_56c8dcb3be26c0a1b19e4fdac57"`,
         );
         await queryRunner.query(
-            `ALTER TABLE "fellowship_report_note" DROP CONSTRAINT "FK_fellowship_report_note_report"`,
+            `ALTER TABLE "fellowship_report_note" DROP CONSTRAINT "FK_1a587c4a095b42730afc09c125d"`,
         );
         await queryRunner.query(`DROP TABLE "fellowship_report_note"`);
     }

--- a/migrations/1786349505574-migrations.ts
+++ b/migrations/1786349505574-migrations.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migrations1786349505574 implements MigrationInterface {
+    name = 'Migrations1786349505574';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE "fellowship_report_note" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "body" text NOT NULL, "reportId" uuid, "authorId" uuid, CONSTRAINT "PK_fellowship_report_note" PRIMARY KEY ("id"))`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_report_note" ADD CONSTRAINT "FK_fellowship_report_note_report" FOREIGN KEY ("reportId") REFERENCES "fellowship_report"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_report_note" ADD CONSTRAINT "FK_fellowship_report_note_author" FOREIGN KEY ("authorId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_report_note" DROP CONSTRAINT "FK_fellowship_report_note_author"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_report_note" DROP CONSTRAINT "FK_fellowship_report_note_report"`,
+        );
+        await queryRunner.query(`DROP TABLE "fellowship_report_note"`);
+    }
+}

--- a/src/entities/entities.ts
+++ b/src/entities/entities.ts
@@ -12,6 +12,7 @@ import { FellowshipApplicationNote } from '@/entities/fellowship-application-not
 import { Fellowship } from '@/entities/fellowship.entity';
 import { FellowshipDocument } from '@/entities/fellowship-document.entity';
 import { FellowshipReport } from '@/entities/fellowship-report.entity';
+import { FellowshipReportNote } from '@/entities/fellowship-report-note.entity';
 
 export const entities = [
     APITask,
@@ -26,6 +27,7 @@ export const entities = [
     FellowshipApplicationNote,
     FellowshipDocument,
     FellowshipReport,
+    FellowshipReportNote,
     GroupDiscussionScore,
     User,
 ];

--- a/src/entities/fellowship-report-note.entity.ts
+++ b/src/entities/fellowship-report-note.entity.ts
@@ -1,0 +1,24 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseEntity } from '@/entities/base.entity';
+import { FellowshipReport } from '@/entities/fellowship-report.entity';
+import { User } from '@/entities/user.entity';
+
+// Internal, admin-only notes left on a fellowship report while reviewing it — a
+// shared thread visible to every admin. Never exposed to the fellow, unlike the
+// fellow-facing `reviewerRemarks` on the report.
+@Entity()
+export class FellowshipReportNote extends BaseEntity {
+    @PrimaryGeneratedColumn('uuid')
+    id!: string;
+
+    @Column('text')
+    body!: string;
+
+    // Deleting a report removes its notes.
+    @ManyToOne(() => FellowshipReport, { onDelete: 'CASCADE' })
+    report!: FellowshipReport;
+
+    // The admin who wrote the note.
+    @ManyToOne(() => User)
+    author!: User;
+}

--- a/src/fellowship-reports/fellowship-report-notes.controller.ts
+++ b/src/fellowship-reports/fellowship-report-notes.controller.ts
@@ -1,0 +1,84 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Param,
+    ParseUUIDPipe,
+    Patch,
+    Post,
+    UsePipes,
+    ValidationPipe,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Roles } from '@/auth/roles.decorator';
+import { UserRole } from '@/common/enum';
+import { GetUser } from '@/decorators/user.decorator';
+import { User } from '@/entities/user.entity';
+import { FellowshipReportNotesService } from '@/fellowship-reports/fellowship-report-notes.service';
+import {
+    CreateFellowshipReportNoteRequestDto,
+    UpdateFellowshipReportNoteRequestDto,
+} from '@/fellowship-reports/fellowship-report-notes.request.dto';
+import { FellowshipReportNoteResponseDto } from '@/fellowship-reports/fellowship-report-notes.response.dto';
+
+// Internal admin notes live as a sub-resource of a report. Every route is
+// admin-only (see the per-route @Roles); reads are shared across admins, while
+// writes are restricted to the note's author in the service.
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@ApiTags('Fellowship Report Notes')
+@ApiBearerAuth()
+@Controller('fellowship-reports/:reportId/notes')
+export class FellowshipReportNotesController {
+    constructor(private readonly service: FellowshipReportNotesService) {}
+
+    @Post()
+    @ApiOperation({
+        summary: 'Add an internal note to a fellowship report (admin)',
+    })
+    @Roles(UserRole.ADMIN)
+    async createNote(
+        @Param('reportId', new ParseUUIDPipe()) reportId: string,
+        @GetUser() user: User,
+        @Body() body: CreateFellowshipReportNoteRequestDto,
+    ): Promise<FellowshipReportNoteResponseDto> {
+        return this.service.createNote(reportId, user, body);
+    }
+
+    @Get()
+    @ApiOperation({
+        summary: 'List internal notes on a fellowship report (admin)',
+    })
+    @Roles(UserRole.ADMIN)
+    async listNotes(
+        @Param('reportId', new ParseUUIDPipe()) reportId: string,
+    ): Promise<FellowshipReportNoteResponseDto[]> {
+        return this.service.listNotes(reportId);
+    }
+
+    @Patch(':noteId')
+    @ApiOperation({ summary: 'Edit one of your own internal notes (admin)' })
+    @Roles(UserRole.ADMIN)
+    async updateNote(
+        @Param('reportId', new ParseUUIDPipe()) reportId: string,
+        @Param('noteId', new ParseUUIDPipe()) noteId: string,
+        @GetUser() user: User,
+        @Body() body: UpdateFellowshipReportNoteRequestDto,
+    ): Promise<FellowshipReportNoteResponseDto> {
+        return this.service.updateNote(reportId, noteId, user, body);
+    }
+
+    @Delete(':noteId')
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Delete one of your own internal notes (admin)' })
+    @Roles(UserRole.ADMIN)
+    async deleteNote(
+        @Param('reportId', new ParseUUIDPipe()) reportId: string,
+        @Param('noteId', new ParseUUIDPipe()) noteId: string,
+        @GetUser() user: User,
+    ): Promise<void> {
+        return this.service.deleteNote(reportId, noteId, user);
+    }
+}

--- a/src/fellowship-reports/fellowship-report-notes.request.dto.ts
+++ b/src/fellowship-reports/fellowship-report-notes.request.dto.ts
@@ -1,0 +1,20 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+// Generous upper bound for an internal note. Only the bound is enforced here;
+// the body is otherwise free-form text.
+export const NOTE_BODY_MAX_LENGTH = 5000;
+
+const trim = ({ value }: { value: unknown }): unknown =>
+    typeof value === 'string' ? value.trim() : value;
+
+export class CreateFellowshipReportNoteRequestDto {
+    @Transform(trim)
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(NOTE_BODY_MAX_LENGTH)
+    body!: string;
+}
+
+// Editing a note replaces its body; same shape and rules as creating one.
+export class UpdateFellowshipReportNoteRequestDto extends CreateFellowshipReportNoteRequestDto {}

--- a/src/fellowship-reports/fellowship-report-notes.response.dto.ts
+++ b/src/fellowship-reports/fellowship-report-notes.response.dto.ts
@@ -1,0 +1,35 @@
+import { FellowshipReportNote } from '@/entities/fellowship-report-note.entity';
+
+export class FellowshipReportNoteResponseDto {
+    id!: string;
+    reportId!: string;
+    body!: string;
+    authorId!: string;
+    authorName!: string;
+    createdAt!: string;
+    updatedAt!: string;
+
+    constructor(obj: FellowshipReportNoteResponseDto) {
+        this.id = obj.id;
+        this.reportId = obj.reportId;
+        this.body = obj.body;
+        this.authorId = obj.authorId;
+        this.authorName = obj.authorName;
+        this.createdAt = obj.createdAt;
+        this.updatedAt = obj.updatedAt;
+    }
+
+    static fromEntity(
+        note: FellowshipReportNote,
+    ): FellowshipReportNoteResponseDto {
+        return new FellowshipReportNoteResponseDto({
+            id: note.id,
+            reportId: note.report.id,
+            body: note.body,
+            authorId: note.author.id,
+            authorName: note.author.displayName,
+            createdAt: note.createdAt.toISOString(),
+            updatedAt: note.updatedAt.toISOString(),
+        });
+    }
+}

--- a/src/fellowship-reports/fellowship-report-notes.service.ts
+++ b/src/fellowship-reports/fellowship-report-notes.service.ts
@@ -1,0 +1,121 @@
+import {
+    ForbiddenException,
+    Injectable,
+    NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FellowshipReport } from '@/entities/fellowship-report.entity';
+import { FellowshipReportNote } from '@/entities/fellowship-report-note.entity';
+import { User } from '@/entities/user.entity';
+import {
+    CreateFellowshipReportNoteRequestDto,
+    UpdateFellowshipReportNoteRequestDto,
+} from '@/fellowship-reports/fellowship-report-notes.request.dto';
+import { FellowshipReportNoteResponseDto } from '@/fellowship-reports/fellowship-report-notes.response.dto';
+
+@Injectable()
+export class FellowshipReportNotesService {
+    constructor(
+        @InjectRepository(FellowshipReportNote)
+        private readonly noteRepository: Repository<FellowshipReportNote>,
+        @InjectRepository(FellowshipReport)
+        private readonly reportRepository: Repository<FellowshipReport>,
+    ) {}
+
+    async createNote(
+        reportId: string,
+        author: User,
+        dto: CreateFellowshipReportNoteRequestDto,
+    ): Promise<FellowshipReportNoteResponseDto> {
+        const report = await this.getReportOrThrow(reportId);
+
+        const note = this.noteRepository.create({
+            body: dto.body,
+            report,
+            author,
+        });
+        const { id } = await this.noteRepository.save(note);
+
+        // Reload so timestamps and the author relation are populated from the DB.
+        return FellowshipReportNoteResponseDto.fromEntity(
+            await this.getNoteOrThrow(reportId, id),
+        );
+    }
+
+    async listNotes(
+        reportId: string,
+    ): Promise<FellowshipReportNoteResponseDto[]> {
+        await this.getReportOrThrow(reportId);
+
+        const notes = await this.noteRepository.find({
+            where: { report: { id: reportId } },
+            relations: { report: true, author: true },
+            order: { createdAt: 'ASC' },
+        });
+
+        return notes.map(FellowshipReportNoteResponseDto.fromEntity);
+    }
+
+    async updateNote(
+        reportId: string,
+        noteId: string,
+        user: User,
+        dto: UpdateFellowshipReportNoteRequestDto,
+    ): Promise<FellowshipReportNoteResponseDto> {
+        const note = await this.getNoteOrThrow(reportId, noteId);
+        this.assertAuthor(note, user);
+
+        note.body = dto.body;
+        await this.noteRepository.save(note);
+
+        return FellowshipReportNoteResponseDto.fromEntity(note);
+    }
+
+    async deleteNote(
+        reportId: string,
+        noteId: string,
+        user: User,
+    ): Promise<void> {
+        const note = await this.getNoteOrThrow(reportId, noteId);
+        this.assertAuthor(note, user);
+
+        await this.noteRepository.remove(note);
+    }
+
+    private async getReportOrThrow(
+        reportId: string,
+    ): Promise<FellowshipReport> {
+        const report = await this.reportRepository.findOne({
+            where: { id: reportId },
+            select: { id: true },
+        });
+        if (!report) {
+            throw new NotFoundException('Report not found');
+        }
+        return report;
+    }
+
+    // Scoped to the report so a note cannot be reached through the wrong report
+    // path. Loads the author for the ownership check and response.
+    private async getNoteOrThrow(
+        reportId: string,
+        noteId: string,
+    ): Promise<FellowshipReportNote> {
+        const note = await this.noteRepository.findOne({
+            where: { id: noteId, report: { id: reportId } },
+            relations: { report: true, author: true },
+        });
+        if (!note) {
+            throw new NotFoundException('Note not found');
+        }
+        return note;
+    }
+
+    // Admins may edit or delete only the notes they authored.
+    private assertAuthor(note: FellowshipReportNote, user: User): void {
+        if (note.author.id !== user.id) {
+            throw new ForbiddenException('You can only modify your own notes');
+        }
+    }
+}

--- a/src/fellowship-reports/fellowship-reports.module.ts
+++ b/src/fellowship-reports/fellowship-reports.module.ts
@@ -1,19 +1,27 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { FellowshipReport } from '@/entities/fellowship-report.entity';
+import { FellowshipReportNote } from '@/entities/fellowship-report-note.entity';
 import { Fellowship } from '@/entities/fellowship.entity';
 import { APITask } from '@/entities/api-task.entity';
 import { FellowshipReportsService } from '@/fellowship-reports/fellowship-reports.service';
 import { FellowshipReportsController } from '@/fellowship-reports/fellowship-reports.controller';
+import { FellowshipReportNotesService } from '@/fellowship-reports/fellowship-report-notes.service';
+import { FellowshipReportNotesController } from '@/fellowship-reports/fellowship-report-notes.controller';
 import { MailModule } from '@/mail/mail.module';
 
 @Module({
     imports: [
-        TypeOrmModule.forFeature([FellowshipReport, Fellowship, APITask]),
+        TypeOrmModule.forFeature([
+            FellowshipReport,
+            FellowshipReportNote,
+            Fellowship,
+            APITask,
+        ]),
         MailModule,
     ],
-    providers: [FellowshipReportsService],
-    controllers: [FellowshipReportsController],
+    providers: [FellowshipReportsService, FellowshipReportNotesService],
+    controllers: [FellowshipReportsController, FellowshipReportNotesController],
     exports: [FellowshipReportsService],
 })
 export class FellowshipReportsModule {}


### PR DESCRIPTION
## Summary

Adds internal, admin-only **notes on fellowship reports** — a shared thread attached to a single report, visible to every admin and never shown to the fellow. This mirrors the existing `FellowshipApplicationNote` feature, re-pointed from applications to reports. It is distinct from the fellow-facing `reviewerRemarks` already on a report.

## Behavior

- All routes are admin-only, mounted under `/fellowship-reports/:reportId/notes`.
- Reads are shared across admins; **edit/delete are restricted to the note's author**.
- Deleting a report cascades to its notes.

| Method | Path | Purpose |
|---|---|---|
| POST | `/fellowship-reports/:reportId/notes` | Create a note |
| GET | `/fellowship-reports/:reportId/notes` | List notes (oldest → newest) |
| PATCH | `/fellowship-reports/:reportId/notes/:noteId` | Edit your own note |
| DELETE | `/fellowship-reports/:reportId/notes/:noteId` | Delete your own note |

`body` is required, trimmed, non-empty, max 5000 chars.

## Changes

Four small, layered commits (data model → DTOs → service → routes/wiring):

- `FellowshipReportNote` entity + migration (`fellowship_report_note` table, FK to report with `ON DELETE CASCADE`, FK to author), registered in the entity list.
- Request/response DTOs.
- Notes service (report-scoped lookups, author-only write checks).
- Notes controller and module wiring.

## Migration

Adds `migrations/1786349505574-migrations.ts`, which creates the `fellowship_report_note` table. Run `npm run migration:run` on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
