### PR TITLE
feat: support starter grants as a fellowship kind

### DIFF
--- a/migrations/1786377793901-migrations.ts
+++ b/migrations/1786377793901-migrations.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migrations1786377793901 implements MigrationInterface {
+    name = 'Migrations1786377793901';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TYPE "public"."fellowship_kind_enum" AS ENUM('FELLOWSHIP', 'STARTER_GRANT')`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship" ADD "kind" "public"."fellowship_kind_enum" NOT NULL DEFAULT 'FELLOWSHIP'`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "fellowship" DROP COLUMN "kind"`);
+        await queryRunner.query(`DROP TYPE "public"."fellowship_kind_enum"`);
+    }
+}

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -80,6 +80,15 @@ export enum FellowshipType {
     EDUCATOR = 'EDUCATOR',
 }
 
+// The tier of a fellowship. STARTER_GRANT is a higher-tier, full-time,
+// invite-only variant; it is orthogonal to FellowshipType (a starter grant can
+// still be a DEVELOPER, etc.) and is set by an admin when accepting an
+// application.
+export enum FellowshipKind {
+    FELLOWSHIP = 'FELLOWSHIP',
+    STARTER_GRANT = 'STARTER_GRANT',
+}
+
 export enum FellowshipApplicationStatus {
     DRAFT = 'DRAFT',
     SUBMITTED = 'SUBMITTED',

--- a/src/entities/fellowship.entity.ts
+++ b/src/entities/fellowship.entity.ts
@@ -8,7 +8,11 @@ import {
     PrimaryGeneratedColumn,
 } from 'typeorm';
 import { BaseEntity } from '@/entities/base.entity';
-import { FellowshipType, FellowshipStatus } from '@/common/enum';
+import {
+    FellowshipType,
+    FellowshipStatus,
+    FellowshipKind,
+} from '@/common/enum';
 import { User } from '@/entities/user.entity';
 import { FellowshipApplication } from '@/entities/fellowship-application.entity';
 import { FellowshipReport } from '@/entities/fellowship-report.entity';
@@ -20,6 +24,15 @@ export class Fellowship extends BaseEntity {
 
     @Column({ type: 'enum', enum: FellowshipType })
     type!: FellowshipType;
+
+    // Fellowship tier. Defaults to FELLOWSHIP so existing rows backfill; set to
+    // STARTER_GRANT by an admin at accept time.
+    @Column({
+        type: 'enum',
+        enum: FellowshipKind,
+        default: FellowshipKind.FELLOWSHIP,
+    })
+    kind!: FellowshipKind;
 
     @Column({
         type: 'enum',

--- a/src/fellowship-applications/fellowship-applications.request.dto.ts
+++ b/src/fellowship-applications/fellowship-applications.request.dto.ts
@@ -18,6 +18,7 @@ import { PaginatedQueryDto } from '@/common/dto';
 import {
     FellowshipType,
     FellowshipApplicationStatus,
+    FellowshipKind,
     SortOrder,
 } from '@/common/enum';
 import {
@@ -230,6 +231,14 @@ export class ReviewFellowshipApplicationRequestDto {
     @IsString()
     @IsNotEmpty()
     reviewerRemarks?: string;
+
+    // The fellowship tier to provision on accept. Only consumed when status is
+    // ACCEPTED; defaults to FELLOWSHIP when omitted. Applicants never send
+    // this — it is the admin's invite-only classification (starter grants are
+    // not self-selectable).
+    @IsOptional()
+    @IsEnum(FellowshipKind)
+    kind?: FellowshipKind;
 
     // Accepting an application is a multipart request that also carries the
     // Bitshala-signed unsigned-contract PDF (validated in the controller/service),

--- a/src/fellowship-applications/fellowship-applications.service.ts
+++ b/src/fellowship-applications/fellowship-applications.service.ts
@@ -11,6 +11,7 @@ import { FellowshipApplication } from '@/entities/fellowship-application.entity'
 import { User } from '@/entities/user.entity';
 import {
     FellowshipApplicationStatus,
+    FellowshipKind,
     FellowshipType,
     SortOrder,
     UserRole,
@@ -655,6 +656,7 @@ export class FellowshipApplicationsService {
                     application,
                     reviewer,
                     file!,
+                    dto.kind ?? FellowshipKind.FELLOWSHIP,
                 );
             acceptedFellowshipId = fellowship.id;
         } else {

--- a/src/fellowship-documents/fellowship-documents.service.ts
+++ b/src/fellowship-documents/fellowship-documents.service.ts
@@ -16,6 +16,7 @@ import { User } from '@/entities/user.entity';
 import {
     FellowshipDocumentStatus,
     FellowshipDocumentType,
+    FellowshipKind,
     FellowshipStatus,
     UserRole,
 } from '@/common/enum';
@@ -75,6 +76,7 @@ export class FellowshipDocumentsService {
         application: FellowshipApplication,
         reviewer: User,
         file: Express.Multer.File,
+        kind: FellowshipKind = FellowshipKind.FELLOWSHIP,
     ): Promise<Fellowship> {
         this.assertValidPdf(file);
 
@@ -119,6 +121,7 @@ export class FellowshipDocumentsService {
 
                 const fellowship = manager.create(Fellowship, {
                     type: application.type,
+                    kind,
                     user: application.applicant,
                     application,
                     status: FellowshipStatus.AWAITING_DOCUMENTS,

--- a/src/fellowships/fellowships.controller.ts
+++ b/src/fellowships/fellowships.controller.ts
@@ -35,6 +35,7 @@ import { Roles } from '@/auth/roles.decorator';
 import {
     FellowshipStatus,
     FellowshipType,
+    FellowshipKind,
     SortOrder,
     UserRole,
 } from '@/common/enum';
@@ -158,6 +159,7 @@ export class FellowshipsController {
     @ApiQuery({ name: 'pageSize', type: 'number', required: false })
     @ApiQuery({ name: 'status', enum: FellowshipStatus, required: false })
     @ApiQuery({ name: 'type', enum: FellowshipType, required: false })
+    @ApiQuery({ name: 'kind', enum: FellowshipKind, required: false })
     @ApiQuery({ name: 'search', type: 'string', required: false })
     @ApiQuery({ name: 'sortBy', enum: FellowshipSortBy, required: false })
     @ApiQuery({ name: 'sortOrder', enum: SortOrder, required: false })

--- a/src/fellowships/fellowships.request.dto.ts
+++ b/src/fellowships/fellowships.request.dto.ts
@@ -12,7 +12,12 @@ import {
 } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { PaginatedQueryDto } from '@/common/dto';
-import { FellowshipStatus, FellowshipType, SortOrder } from '@/common/enum';
+import {
+    FellowshipStatus,
+    FellowshipType,
+    FellowshipKind,
+    SortOrder,
+} from '@/common/enum';
 
 export class StartFellowshipContractDto {
     @IsDateString({ strict: true })
@@ -48,6 +53,10 @@ export class ListFellowshipsQueryDto extends PaginatedQueryDto {
     @IsOptional()
     @IsEnum(FellowshipType)
     type?: FellowshipType;
+
+    @IsOptional()
+    @IsEnum(FellowshipKind)
+    kind?: FellowshipKind;
 
     /**
      * Case-insensitive substring match on the application's project name,

--- a/src/fellowships/fellowships.response.dto.ts
+++ b/src/fellowships/fellowships.response.dto.ts
@@ -1,9 +1,14 @@
-import { FellowshipType, FellowshipStatus } from '@/common/enum';
+import {
+    FellowshipType,
+    FellowshipStatus,
+    FellowshipKind,
+} from '@/common/enum';
 import { Fellowship } from '@/entities/fellowship.entity';
 
 export class FellowshipResponseDto {
     id!: string;
     type!: FellowshipType;
+    kind!: FellowshipKind;
     status!: FellowshipStatus;
     mentorContact!: string | null;
     projectName!: string | null;
@@ -33,6 +38,7 @@ export class FellowshipResponseDto {
     constructor(obj: FellowshipResponseDto) {
         this.id = obj.id;
         this.type = obj.type;
+        this.kind = obj.kind;
         this.status = obj.status;
         this.mentorContact = obj.mentorContact;
         this.projectName = obj.projectName;
@@ -68,6 +74,7 @@ export class FellowshipResponseDto {
         return new FellowshipResponseDto({
             id: fellowship.id,
             type: fellowship.type,
+            kind: fellowship.kind,
             status: fellowship.status,
             mentorContact: application.mentorContact,
             projectName: application.projectName,

--- a/src/fellowships/fellowships.service.ts
+++ b/src/fellowships/fellowships.service.ts
@@ -151,6 +151,10 @@ export class FellowshipsService {
             qb.andWhere('fellowship.type = :type', { type: query.type });
         }
 
+        if (query.kind) {
+            qb.andWhere('fellowship.kind = :kind', { kind: query.kind });
+        }
+
         if (query.search) {
             qb.andWhere(
                 new Brackets((w) =>


### PR DESCRIPTION
Adds "starter grants" as a higher-tier, invite-only variant of a fellowship, modeled as a new `FellowshipKind` (`FELLOWSHIP` | `STARTER_GRANT`) on the `Fellowship` entity. An admin sets the kind when accepting an application, so applicants never see it and starter grants stay invite-only; it defaults to `FELLOWSHIP`, and the included migration backfills existing rows. The kind is surfaced on the fellowship response and can be filtered on the admin fellowships list via `?kind=`. No stipend or duration changes — the existing amount cap and start-contract flow are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
