### PR TITLE
feat: admin user search + user overview endpoints

### DIFF
--- a/src/fellowships/fellowships.service.ts
+++ b/src/fellowships/fellowships.service.ts
@@ -110,6 +110,19 @@ export class FellowshipsService {
         });
     }
 
+    async getUserFellowships(userId: string): Promise<FellowshipResponseDto[]> {
+        const fellowships = await this.fellowshipRepository.find({
+            where: { user: { id: userId } },
+            relations: {
+                user: true,
+                application: true,
+            },
+            order: { createdAt: 'DESC' },
+        });
+
+        return fellowships.map(FellowshipResponseDto.fromEntity);
+    }
+
     async getFellowshipById(
         id: string,
         user: User,

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -3,6 +3,7 @@ import {
     Controller,
     Get,
     Param,
+    ParseUUIDPipe,
     Patch,
     Query,
     UsePipes,
@@ -49,6 +50,16 @@ export class UsersController {
     @ApiOperation({ summary: 'Get current user profile' })
     getMe(@GetUser() user: User) {
         return this.usersService.getMe(user);
+    }
+
+    @Get(':id/overview')
+    @ApiOperation({
+        summary:
+            'Get a user overview: profile, cohort participation and fellowships (admin)',
+    })
+    @Roles(UserRole.ADMIN)
+    getUserOverview(@Param('id', new ParseUUIDPipe()) id: string) {
+        return this.usersService.getUserOverview(id);
     }
 
     @Get(':id')

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,20 +1,49 @@
-import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Get,
+    Param,
+    Patch,
+    Query,
+    UsePipes,
+    ValidationPipe,
+} from '@nestjs/common';
 import { UsersService } from '@/users/users.service';
 import { GetUser } from '@/decorators/user.decorator';
 import { User } from '@/entities/user.entity';
 import {
+    ListUsersQueryDto,
     UpdateUserRequest,
     UpdateUserRoleRequest,
+    UserSortBy,
 } from '@/users/users.request';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+    ApiBearerAuth,
+    ApiOperation,
+    ApiQuery,
+    ApiTags,
+} from '@nestjs/swagger';
 import { Roles } from '@/auth/roles.decorator';
-import { UserRole } from '@/common/enum';
+import { SortOrder, UserRole } from '@/common/enum';
 
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 @ApiTags('Users')
 @ApiBearerAuth()
 @Controller('users')
 export class UsersController {
     constructor(private readonly usersService: UsersService) {}
+
+    @Get()
+    @ApiOperation({ summary: 'Search users (admin)' })
+    @Roles(UserRole.ADMIN)
+    @ApiQuery({ name: 'page', type: 'number', required: false })
+    @ApiQuery({ name: 'pageSize', type: 'number', required: false })
+    @ApiQuery({ name: 'search', type: 'string', required: false })
+    @ApiQuery({ name: 'sortBy', enum: UserSortBy, required: false })
+    @ApiQuery({ name: 'sortOrder', enum: SortOrder, required: false })
+    searchUsers(@Query() query: ListUsersQueryDto) {
+        return this.usersService.searchUsers(query);
+    }
 
     @Get('me')
     @ApiOperation({ summary: 'Get current user profile' })

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -3,9 +3,17 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '@/entities/user.entity';
 import { UsersService } from '@/users/users.service';
 import { UsersController } from '@/users/users.controller';
+import { ScoresModule } from '@/scores/scores.module';
+import { CertificatesModule } from '@/certificates/certificates.module';
+import { FellowshipsModule } from '@/fellowships/fellowships.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([User])],
+    imports: [
+        TypeOrmModule.forFeature([User]),
+        ScoresModule,
+        CertificatesModule,
+        FellowshipsModule,
+    ],
     providers: [UsersService],
     controllers: [UsersController],
     exports: [UsersService],

--- a/src/users/users.request.ts
+++ b/src/users/users.request.ts
@@ -13,7 +13,9 @@ import {
     IsEnum,
     IsEmail,
 } from 'class-validator';
-import { UserRole } from '@/common/enum';
+import { Transform } from 'class-transformer';
+import { PaginatedQueryDto } from '@/common/dto';
+import { SortOrder, UserRole } from '@/common/enum';
 
 export class UpdateUserRequest {
     @IsOptional()
@@ -108,4 +110,32 @@ export class UpdateUserRoleRequest {
 
     @IsEnum(UserRole)
     role: UserRole;
+}
+
+export enum UserSortBy {
+    CREATED_AT = 'createdAt',
+    NAME = 'name',
+    EMAIL = 'email',
+}
+
+export class ListUsersQueryDto extends PaginatedQueryDto {
+    /**
+     * Case-insensitive substring match on the user's name, email and Discord
+     * usernames.
+     */
+    @IsOptional()
+    @Transform(({ value }) =>
+        typeof value === 'string' ? value.trim() : value,
+    )
+    @IsString()
+    @MaxLength(100)
+    search?: string;
+
+    @IsOptional()
+    @IsEnum(UserSortBy)
+    sortBy: UserSortBy = UserSortBy.CREATED_AT;
+
+    @IsOptional()
+    @IsEnum(SortOrder)
+    sortOrder: SortOrder = SortOrder.DESC;
 }

--- a/src/users/users.response.ts
+++ b/src/users/users.response.ts
@@ -1,6 +1,15 @@
 // dto/get-user.response.ts
 import { User } from '@/entities/user.entity';
-import { UserRole } from '@/common/enum';
+import {
+    CertificateType,
+    CohortType,
+    FellowshipStatus,
+    TopPerformerRank,
+    UserRole,
+} from '@/common/enum';
+import { GetCertificateResponseDto } from '@/certificates/certificates.response.dto';
+import { GetUsersScoresResponseDto } from '@/scores/scores.response.dto';
+import { FellowshipResponseDto } from '@/fellowships/fellowships.response.dto';
 
 export class GetUserResponse {
     id: string;
@@ -75,6 +84,109 @@ export class UserSummaryResponseDto {
             discordGlobalName: user.discordGlobalName,
             role: user.role,
             createdAt: user.createdAt.toISOString(),
+        });
+    }
+}
+
+export class UserCohortCertificateDto {
+    certificateType: CertificateType;
+    rank: TopPerformerRank | null;
+    withExercises: boolean;
+    issuedAt: string;
+
+    constructor(partial: Partial<UserCohortCertificateDto>) {
+        Object.assign(this, partial);
+    }
+}
+
+export class UserCohortParticipationDto {
+    cohortId: string;
+    cohortType: CohortType;
+    seasonNumber: number;
+    totalScore: number;
+    maxTotalScore: number;
+    scorePercent: number;
+    attendedWeeks: number;
+    totalWeeks: number;
+    attendancePercent: number;
+    // A cohort counts as completed once the user has earned a certificate for it.
+    completed: boolean;
+    certificate: UserCohortCertificateDto | null;
+
+    constructor(partial: Partial<UserCohortParticipationDto>) {
+        Object.assign(this, partial);
+    }
+}
+
+export class UserOverviewResponseDto {
+    profile: GetUserResponse;
+    joinedAt: string;
+    isGuildMember: boolean;
+    cohortSummary: { enrolledCount: number; completedCount: number };
+    cohorts: UserCohortParticipationDto[];
+    fellowshipSummary: { totalCount: number; completedCount: number };
+    fellowships: FellowshipResponseDto[];
+
+    constructor(partial: Partial<UserOverviewResponseDto>) {
+        Object.assign(this, partial);
+    }
+
+    static fromParts(
+        user: User,
+        scores: GetUsersScoresResponseDto,
+        certificates: GetCertificateResponseDto[],
+        fellowships: FellowshipResponseDto[],
+    ): UserOverviewResponseDto {
+        const certificateByCohortId = new Map(
+            certificates.map((certificate) => [
+                certificate.cohortId,
+                certificate,
+            ]),
+        );
+
+        const cohorts = scores.cohorts.map((cohort) => {
+            const certificate =
+                certificateByCohortId.get(cohort.cohortId) ?? null;
+            return new UserCohortParticipationDto({
+                cohortId: cohort.cohortId,
+                cohortType: cohort.cohortType,
+                seasonNumber: cohort.seasonNumber,
+                totalScore: cohort.totalScore,
+                maxTotalScore: cohort.maxTotalScore,
+                scorePercent: cohort.scorePercent,
+                attendedWeeks: cohort.attendedWeeks,
+                totalWeeks: cohort.totalWeeks,
+                attendancePercent: cohort.attendancePercent,
+                completed: certificate !== null,
+                certificate: certificate
+                    ? new UserCohortCertificateDto({
+                          certificateType: certificate.certificateType,
+                          rank: certificate.rank,
+                          withExercises: certificate.withExercises,
+                          issuedAt: certificate.createdAt,
+                      })
+                    : null,
+            });
+        });
+
+        return new UserOverviewResponseDto({
+            profile: GetUserResponse.fromEntity(user),
+            joinedAt: user.createdAt.toISOString(),
+            isGuildMember: user.isGuildMember,
+            cohortSummary: {
+                enrolledCount: cohorts.length,
+                completedCount: cohorts.filter((cohort) => cohort.completed)
+                    .length,
+            },
+            cohorts,
+            fellowshipSummary: {
+                totalCount: fellowships.length,
+                completedCount: fellowships.filter(
+                    (fellowship) =>
+                        fellowship.status === FellowshipStatus.COMPLETED,
+                ).length,
+            },
+            fellowships,
         });
     }
 }

--- a/src/users/users.response.ts
+++ b/src/users/users.response.ts
@@ -1,5 +1,6 @@
 // dto/get-user.response.ts
 import { User } from '@/entities/user.entity';
+import { UserRole } from '@/common/enum';
 
 export class GetUserResponse {
     id: string;
@@ -46,6 +47,34 @@ export class GetUserResponse {
             weeklyCohortCommitmentHours: user.weeklyCohortCommitmentHours,
             location: user.location,
             referral: user.referral,
+        });
+    }
+}
+
+export class UserSummaryResponseDto {
+    id: string;
+    displayName: string;
+    name: string | null;
+    email: string | null;
+    discordUsername: string;
+    discordGlobalName: string | null;
+    role: UserRole;
+    createdAt: string;
+
+    constructor(partial: Partial<UserSummaryResponseDto>) {
+        Object.assign(this, partial);
+    }
+
+    static fromEntity(user: User): UserSummaryResponseDto {
+        return new UserSummaryResponseDto({
+            id: user.id,
+            displayName: user.displayName,
+            name: user.name,
+            email: user.email,
+            discordUsername: user.discordUserName,
+            discordGlobalName: user.discordGlobalName,
+            role: user.role,
+            createdAt: user.createdAt.toISOString(),
         });
     }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -6,6 +6,7 @@ import { SortOrder, UserRole } from '@/common/enum';
 import { randomUUID } from 'crypto';
 import {
     GetUserResponse,
+    UserOverviewResponseDto,
     UserSummaryResponseDto,
 } from '@/users/users.response';
 import {
@@ -17,6 +18,9 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { escapeLikePattern } from '@/common/common';
 import { PaginatedDataDto } from '@/common/dto';
+import { ScoresService } from '@/scores/scores.service';
+import { CertificatesService } from '@/certificates/certificates.service';
+import { FellowshipsService } from '@/fellowships/fellowships.service';
 
 const USER_SORT_COLUMNS: Record<UserSortBy, string> = {
     [UserSortBy.CREATED_AT]: 'user.createdAt',
@@ -32,6 +36,9 @@ export class UsersService {
     constructor(
         @InjectRepository(User) private userRepository: Repository<User>,
         private readonly configService: ConfigService,
+        private readonly scoresService: ScoresService,
+        private readonly certificatesService: CertificatesService,
+        private readonly fellowshipsService: FellowshipsService,
     ) {
         this.adminRoleId = this.configService.getOrThrow<string>(
             'discord.roles.admin',
@@ -166,6 +173,23 @@ export class UsersService {
             totalRecords,
             records: records.map(UserSummaryResponseDto.fromEntity),
         });
+    }
+
+    async getUserOverview(userId: string): Promise<UserOverviewResponseDto> {
+        const user = await this.findByUserId(userId);
+
+        const [scores, certificates, fellowships] = await Promise.all([
+            this.scoresService.getUserScores(userId),
+            this.certificatesService.getUserCertificates(userId),
+            this.fellowshipsService.getUserFellowships(userId),
+        ]);
+
+        return UserOverviewResponseDto.fromParts(
+            user,
+            scores,
+            certificates,
+            fellowships,
+        );
     }
 
     async updateMe(

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,15 +1,28 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '@/entities/user.entity';
-import { Repository } from 'typeorm';
-import { UserRole } from '@/common/enum';
+import { Brackets, Repository } from 'typeorm';
+import { SortOrder, UserRole } from '@/common/enum';
 import { randomUUID } from 'crypto';
-import { GetUserResponse } from '@/users/users.response';
 import {
+    GetUserResponse,
+    UserSummaryResponseDto,
+} from '@/users/users.response';
+import {
+    ListUsersQueryDto,
     UpdateUserRequest,
     UpdateUserRoleRequest,
+    UserSortBy,
 } from '@/users/users.request';
 import { ConfigService } from '@nestjs/config';
+import { escapeLikePattern } from '@/common/common';
+import { PaginatedDataDto } from '@/common/dto';
+
+const USER_SORT_COLUMNS: Record<UserSortBy, string> = {
+    [UserSortBy.CREATED_AT]: 'user.createdAt',
+    [UserSortBy.NAME]: 'user.name',
+    [UserSortBy.EMAIL]: 'user.email',
+};
 
 @Injectable()
 export class UsersService {
@@ -120,6 +133,39 @@ export class UsersService {
     async getUserById(userId: string): Promise<GetUserResponse> {
         const user = await this.findByUserId(userId);
         return GetUserResponse.fromEntity(user);
+    }
+
+    async searchUsers(
+        query: ListUsersQueryDto,
+    ): Promise<PaginatedDataDto<UserSummaryResponseDto>> {
+        const qb = this.userRepository.createQueryBuilder('user');
+
+        if (query.search) {
+            qb.andWhere(
+                new Brackets((w) =>
+                    w
+                        .where('user.name ILIKE :search')
+                        .orWhere('user.email ILIKE :search')
+                        .orWhere('user.discordUserName ILIKE :search')
+                        .orWhere('user.discordGlobalName ILIKE :search'),
+                ),
+                { search: `%${escapeLikePattern(query.search)}%` },
+            );
+        }
+
+        const order = query.sortOrder === SortOrder.ASC ? 'ASC' : 'DESC';
+
+        const [records, totalRecords] = await qb
+            .orderBy(USER_SORT_COLUMNS[query.sortBy], order, 'NULLS LAST')
+            .addOrderBy('user.id', 'ASC')
+            .skip(query.page * query.pageSize)
+            .take(query.pageSize)
+            .getManyAndCount();
+
+        return new PaginatedDataDto({
+            totalRecords,
+            records: records.map(UserSummaryResponseDto.fromEntity),
+        });
     }
 
     async updateMe(


### PR DESCRIPTION
## Summary

Adds two admin-only (`@Roles(UserRole.ADMIN)`) read endpoints so an admin can look up a
user and see a consolidated picture of their participation, instead of stitching several
scoped calls together by hand.

- `GET /users` — paginated user search over name, email and Discord usernames.
- `GET /users/:id/overview` — the user's profile plus per-cohort participation (score,
  attendance, certificate status), a cohort-completion summary, and their fellowship
  participation.

## Details

**`GET /users`** — `search` (≤100 chars, case-insensitive over name / email / Discord
names), `page` (zero-based), `pageSize` (≤100), `sortBy` (`createdAt` | `name` | `email`),
`sortOrder`. Returns `PaginatedDataDto<UserSummaryResponseDto>`. Reuses the shared
`Brackets` + `ILIKE` + `escapeLikePattern` query pattern.

**`GET /users/:id/overview`** — returns `UserOverviewResponseDto`: `profile`, `joinedAt`,
`isGuildMember`, `cohortSummary { enrolledCount, completedCount }`, `cohorts[]` (each with
score %, attendance %, `completed`, and `certificate` or `null`),
`fellowshipSummary { totalCount, completedCount }`, and `fellowships[]`. A cohort counts as
completed when the user earned a certificate for it.

Pure read-only aggregation over existing services — `ScoresService.getUserScores`,
`CertificatesService.getUserCertificates`, and a new thin
`FellowshipsService.getUserFellowships`.

## Notes

- No DB migration — read-only over existing tables.
- `UsersModule` now imports `ScoresModule` / `CertificatesModule` / `FellowshipsModule`;
  the dependency is one-directional (none import `UsersModule`), so no circular dependency.
- Access is admins only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)