### PR TITLE
Revamp the education fellowship application questionnaire

### DIFF
--- a/migrations/1786525636000-migrations.ts
+++ b/migrations/1786525636000-migrations.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migrations1786525636000 implements MigrationInterface {
+    name = 'Migrations1786525636000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TYPE "public"."fellowship_application_educationcategory_enum" AS ENUM('MEETUP', 'CLUB', 'COHORT_TA', 'OTHER')`,
+        );
+        await queryRunner.query(
+            `CREATE TYPE "public"."fellowship_application_cohorttype_enum" AS ENUM('MASTERING_BITCOIN', 'LEARNING_BITCOIN_FROM_COMMAND_LINE', 'PROGRAMMING_BITCOIN', 'BITCOIN_PROTOCOL_DEVELOPMENT', 'MASTERING_LIGHTNING_NETWORK', 'BUILDING_BITCOIN_IN_RUST')`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_application" ADD "educationCategory" "public"."fellowship_application_educationcategory_enum"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_application" ADD "cohortType" "public"."fellowship_application_cohorttype_enum"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_application" ADD "city" text`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_application" ADD "educationCategoryOther" text`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_application" ADD "scopeOfWork" text`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_application" DROP COLUMN "scopeOfWork"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_application" DROP COLUMN "educationCategoryOther"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_application" DROP COLUMN "city"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_application" DROP COLUMN "cohortType"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "fellowship_application" DROP COLUMN "educationCategory"`,
+        );
+        await queryRunner.query(
+            `DROP TYPE "public"."fellowship_application_cohorttype_enum"`,
+        );
+        await queryRunner.query(
+            `DROP TYPE "public"."fellowship_application_educationcategory_enum"`,
+        );
+    }
+}

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -80,6 +80,15 @@ export enum FellowshipType {
     EDUCATOR = 'EDUCATOR',
 }
 
+// The category of an education (EDUCATOR) fellowship application: TAing a
+// cohort, running a meetup, running a club, or a free-form "other".
+export enum EducationCategory {
+    MEETUP = 'MEETUP',
+    CLUB = 'CLUB',
+    COHORT_TA = 'COHORT_TA',
+    OTHER = 'OTHER',
+}
+
 // The tier of a fellowship. STARTER_GRANT is a higher-tier, full-time,
 // invite-only variant; it is orthogonal to FellowshipType (a starter grant can
 // still be a DEVELOPER, etc.) and is set by an admin when accepting an

--- a/src/entities/fellowship-application.entity.ts
+++ b/src/entities/fellowship-application.entity.ts
@@ -6,7 +6,12 @@ import {
     PrimaryGeneratedColumn,
 } from 'typeorm';
 import { BaseEntity } from '@/entities/base.entity';
-import { FellowshipType, FellowshipApplicationStatus } from '@/common/enum';
+import {
+    FellowshipType,
+    FellowshipApplicationStatus,
+    EducationCategory,
+    CohortType,
+} from '@/common/enum';
 import { User } from '@/entities/user.entity';
 import { Fellowship } from '@/entities/fellowship.entity';
 
@@ -81,6 +86,27 @@ export class FellowshipApplication extends BaseEntity {
 
     @Column('text', { nullable: true })
     questionsForBitshala!: string | null;
+
+    // Education (EDUCATOR) track fields. Populated only for education
+    // applications; null for the developer/designer tracks.
+    @Column({ type: 'enum', enum: EducationCategory, nullable: true })
+    educationCategory!: EducationCategory | null;
+
+    // The course the applicant wants to TA, when educationCategory is COHORT_TA.
+    @Column({ type: 'enum', enum: CohortType, nullable: true })
+    cohortType!: CohortType | null;
+
+    // The city where a meetup will be held, when educationCategory is MEETUP.
+    @Column('text', { nullable: true })
+    city!: string | null;
+
+    // Free-form description of the activity, when educationCategory is OTHER.
+    @Column('text', { nullable: true })
+    educationCategoryOther!: string | null;
+
+    // Monthly scope-of-work breakdown for the education activity.
+    @Column('text', { nullable: true })
+    scopeOfWork!: string | null;
 
     @Column({
         type: 'enum',

--- a/src/fellowship-applications/fellowship-applications.request.dto.ts
+++ b/src/fellowship-applications/fellowship-applications.request.dto.ts
@@ -20,6 +20,8 @@ import {
     FellowshipApplicationStatus,
     FellowshipKind,
     SortOrder,
+    EducationCategory,
+    CohortType,
 } from '@/common/enum';
 import {
     cleanLinks,
@@ -195,6 +197,35 @@ export class ProposalFieldsDto {
     @IsString()
     @MaxLength(LONG_TEXT_LIMIT)
     questionsForBitshala?: string;
+
+    // Education (EDUCATOR) track fields. Optional at the DTO layer like every
+    // other field so drafts autosave with partial data; the conditional
+    // required ruleset runs at submit time in the service.
+    @IsOptional()
+    @IsEnum(EducationCategory)
+    educationCategory?: EducationCategory;
+
+    @IsOptional()
+    @IsEnum(CohortType)
+    cohortType?: CohortType;
+
+    @IsOptional()
+    @Transform(trim)
+    @IsString()
+    @MaxLength(TITLE_LIMIT)
+    city?: string;
+
+    @IsOptional()
+    @Transform(trim)
+    @IsString()
+    @MaxLength(LONG_TEXT_LIMIT)
+    educationCategoryOther?: string;
+
+    @IsOptional()
+    @Transform(trim)
+    @IsString()
+    @MaxLength(LONG_TEXT_LIMIT)
+    scopeOfWork?: string;
 
     // Profile field: written through to the applicant's user profile rather
     // than stored on the application (see service), so it is never duplicated.

--- a/src/fellowship-applications/fellowship-applications.response.dto.ts
+++ b/src/fellowship-applications/fellowship-applications.response.dto.ts
@@ -1,4 +1,9 @@
-import { FellowshipType, FellowshipApplicationStatus } from '@/common/enum';
+import {
+    FellowshipType,
+    FellowshipApplicationStatus,
+    EducationCategory,
+    CohortType,
+} from '@/common/enum';
 import { FellowshipApplication } from '@/entities/fellowship-application.entity';
 
 export class FellowshipApplicationProposalResponseDto {
@@ -23,6 +28,11 @@ export class FellowshipApplicationProposalResponseDto {
     bitcoinOssGoal!: string | null;
     additionalInfo!: string | null;
     questionsForBitshala!: string | null;
+    educationCategory!: EducationCategory | null;
+    cohortType!: CohortType | null;
+    city!: string | null;
+    educationCategoryOther!: string | null;
+    scopeOfWork!: string | null;
 
     static fromEntity(
         application: FellowshipApplication,
@@ -49,6 +59,11 @@ export class FellowshipApplicationProposalResponseDto {
         dto.bitcoinOssGoal = application.bitcoinOssGoal;
         dto.additionalInfo = application.additionalInfo;
         dto.questionsForBitshala = application.questionsForBitshala;
+        dto.educationCategory = application.educationCategory;
+        dto.cohortType = application.cohortType;
+        dto.city = application.city;
+        dto.educationCategoryOther = application.educationCategoryOther;
+        dto.scopeOfWork = application.scopeOfWork;
         return dto;
     }
 }

--- a/src/fellowship-applications/fellowship-applications.service.spec.ts
+++ b/src/fellowship-applications/fellowship-applications.service.spec.ts
@@ -1,0 +1,439 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { FellowshipApplicationsService } from '@/fellowship-applications/fellowship-applications.service';
+import { FellowshipApplication } from '@/entities/fellowship-application.entity';
+import { User } from '@/entities/user.entity';
+import { MailService } from '@/mail/mail.service';
+import { GitHubClassroomClient } from '@/github-classroom/client/github-classroom.client';
+import { FellowshipDocumentsService } from '@/fellowship-documents/fellowship-documents.service';
+import {
+    CohortType,
+    EducationCategory,
+    FellowshipApplicationStatus,
+    FellowshipType,
+} from '@/common/enum';
+
+// Exercises the private validateProposalForSubmit through the public
+// submitApplication. The key invariants: the new EDUCATOR rules, and that the
+// developer/designer rules (and their exact, order-sensitive error output) are
+// unchanged.
+describe('FellowshipApplicationsService — submit validation', () => {
+    let service: FellowshipApplicationsService;
+
+    const applicationRepository = {
+        findOne: jest.fn(),
+        save: jest.fn(),
+    };
+    const mailService = {
+        sendFellowshipApplicationReceivedEmail: jest.fn(),
+    };
+
+    // The authenticated applicant. `location` lives on the profile and is
+    // required to submit on every track.
+    const applicant = {
+        id: 'user-1',
+        displayName: 'Alice',
+        location: 'Pune, India',
+        email: 'alice@example.com',
+    } as unknown as User;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                FellowshipApplicationsService,
+                {
+                    provide: getRepositoryToken(FellowshipApplication),
+                    useValue: applicationRepository,
+                },
+                { provide: getRepositoryToken(User), useValue: {} },
+                { provide: MailService, useValue: mailService },
+                { provide: GitHubClassroomClient, useValue: {} },
+                { provide: FellowshipDocumentsService, useValue: {} },
+            ],
+        }).compile();
+
+        service = module.get(FellowshipApplicationsService);
+        applicationRepository.save.mockImplementation(
+            async (a: FellowshipApplication) => a,
+        );
+        mailService.sendFellowshipApplicationReceivedEmail.mockResolvedValue(
+            undefined,
+        );
+    });
+
+    afterEach(() => jest.resetAllMocks());
+
+    // A valid EDUCATOR (MEETUP) draft. Each test overrides one field.
+    function buildApplication(
+        overrides: Partial<FellowshipApplication> = {},
+    ): FellowshipApplication {
+        return {
+            id: 'app-1',
+            type: FellowshipType.EDUCATOR,
+            status: FellowshipApplicationStatus.DRAFT,
+            applicant,
+            reviewedBy: null,
+            title: null,
+            problemStatement: null,
+            plan: 'A detailed plan of what I will do.',
+            mentorName: null,
+            mentorContact: null,
+            mentorTestimonial: null,
+            github: null,
+            links: [],
+            projectName: null,
+            projectGithubLink: null,
+            academicBackground: 'My academic background.',
+            graduationYear: 2020,
+            professionalExperience: 'My professional experience.',
+            domains: ['bitcoin'],
+            codingLanguages: null,
+            educationInterests: ['teaching'],
+            bitcoinContributions: 'My contributions.',
+            bitcoinMotivation: 'My motivation.',
+            bitcoinOssGoal: 'My OSS goal.',
+            additionalInfo: null,
+            questionsForBitshala: null,
+            educationCategory: EducationCategory.MEETUP,
+            cohortType: null,
+            city: 'Pune',
+            educationCategoryOther: null,
+            scopeOfWork: 'Two meetups per month.',
+            reviewerRemarks: null,
+            driveFolderId: null,
+            fellowship: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            ...overrides,
+        } as unknown as FellowshipApplication;
+    }
+
+    function buildDeveloper(
+        overrides: Partial<FellowshipApplication> = {},
+    ): FellowshipApplication {
+        return buildApplication({
+            type: FellowshipType.DEVELOPER,
+            title: 'My developer proposal',
+            problemStatement: 'The problem I am solving.',
+            mentorName: 'Bob',
+            mentorContact: 'bob@example.com',
+            mentorTestimonial: 'A strong endorsement.',
+            projectName: 'My Project',
+            projectGithubLink: 'https://github.com/alice/project',
+            github: 'alice',
+            codingLanguages: ['rust'],
+            educationCategory: null,
+            city: null,
+            scopeOfWork: null,
+            educationCategoryOther: null,
+            cohortType: null,
+            ...overrides,
+        });
+    }
+
+    function buildDesigner(
+        overrides: Partial<FellowshipApplication> = {},
+    ): FellowshipApplication {
+        return buildApplication({
+            type: FellowshipType.DESIGNER,
+            title: 'My designer proposal',
+            problemStatement: 'The problem I am solving.',
+            mentorName: 'Bob',
+            mentorContact: 'bob@example.com',
+            mentorTestimonial: 'A strong endorsement.',
+            projectName: 'My Project',
+            educationCategory: null,
+            city: null,
+            scopeOfWork: null,
+            educationCategoryOther: null,
+            cohortType: null,
+            ...overrides,
+        });
+    }
+
+    // Submit a valid application and return the (mutated) entity.
+    async function submit(app: FellowshipApplication): Promise<void> {
+        applicationRepository.findOne.mockResolvedValue(app);
+        await service.submitApplication(app.id, applicant);
+    }
+
+    // Submit an invalid application and return the thrown error message.
+    async function submitError(app: FellowshipApplication): Promise<string> {
+        applicationRepository.findOne.mockResolvedValue(app);
+        try {
+            await service.submitApplication(app.id, applicant);
+        } catch (e) {
+            return (e as Error).message;
+        }
+        throw new Error('Expected submitApplication to throw, but it resolved');
+    }
+
+    it('is defined', () => {
+        expect(service).toBeDefined();
+    });
+
+    describe('EDUCATOR — happy paths', () => {
+        it('accepts a MEETUP application with a city', async () => {
+            const app = buildApplication({
+                educationCategory: EducationCategory.MEETUP,
+                city: 'Pune',
+                title: null,
+            });
+            await submit(app);
+            expect(app.status).toBe(FellowshipApplicationStatus.SUBMITTED);
+            expect(applicationRepository.save).toHaveBeenCalled();
+        });
+
+        it('accepts a COHORT_TA application with a course', async () => {
+            const app = buildApplication({
+                educationCategory: EducationCategory.COHORT_TA,
+                cohortType: CohortType.PROGRAMMING_BITCOIN,
+                city: null,
+                title: null,
+            });
+            await submit(app);
+            expect(app.status).toBe(FellowshipApplicationStatus.SUBMITTED);
+        });
+
+        it('accepts a CLUB application with a title', async () => {
+            const app = buildApplication({
+                educationCategory: EducationCategory.CLUB,
+                city: null,
+                title: 'Bitcoin Reading Club, Bangalore',
+            });
+            await submit(app);
+            expect(app.status).toBe(FellowshipApplicationStatus.SUBMITTED);
+        });
+
+        it('accepts an OTHER application with a title and a description', async () => {
+            const app = buildApplication({
+                educationCategory: EducationCategory.OTHER,
+                city: null,
+                title: 'Documentation translation',
+                educationCategoryOther: 'I will translate docs to Hindi.',
+            });
+            await submit(app);
+            expect(app.status).toBe(FellowshipApplicationStatus.SUBMITTED);
+        });
+
+        it('does not require a problem statement for educators', async () => {
+            const app = buildApplication({
+                problemStatement: null,
+                title: null,
+            });
+            await submit(app);
+            expect(app.status).toBe(FellowshipApplicationStatus.SUBMITTED);
+        });
+    });
+
+    describe('EDUCATOR — category rules', () => {
+        it('rejects an application with no category', async () => {
+            const app = buildApplication({ educationCategory: null });
+            expect(await submitError(app)).toContain(
+                'Education category is required',
+            );
+        });
+
+        it('rejects a MEETUP with no city', async () => {
+            const app = buildApplication({
+                educationCategory: EducationCategory.MEETUP,
+                city: null,
+            });
+            expect(await submitError(app)).toContain(
+                'City is required for a meetup',
+            );
+        });
+
+        it('rejects a COHORT_TA with no course', async () => {
+            const app = buildApplication({
+                educationCategory: EducationCategory.COHORT_TA,
+                cohortType: null,
+                city: null,
+            });
+            expect(await submitError(app)).toContain(
+                'A cohort is required when the category is Cohort TA',
+            );
+        });
+
+        it('rejects an OTHER with no description', async () => {
+            const app = buildApplication({
+                educationCategory: EducationCategory.OTHER,
+                city: null,
+                title: 'Something',
+                educationCategoryOther: null,
+            });
+            expect(await submitError(app)).toContain(
+                'A description is required when the category is Other',
+            );
+        });
+    });
+
+    describe('EDUCATOR — title conditionality', () => {
+        it('requires a title for CLUB', async () => {
+            const app = buildApplication({
+                educationCategory: EducationCategory.CLUB,
+                city: null,
+                title: null,
+            });
+            expect(await submitError(app)).toContain('Title is required');
+        });
+
+        it('requires a title for OTHER', async () => {
+            const app = buildApplication({
+                educationCategory: EducationCategory.OTHER,
+                city: null,
+                title: null,
+                educationCategoryOther: 'A description.',
+            });
+            expect(await submitError(app)).toContain('Title is required');
+        });
+
+        it('does not require a title for MEETUP', async () => {
+            const app = buildApplication({
+                educationCategory: EducationCategory.MEETUP,
+                city: 'Pune',
+                title: null,
+            });
+            await submit(app);
+            expect(app.status).toBe(FellowshipApplicationStatus.SUBMITTED);
+        });
+    });
+
+    describe('EDUCATOR — fields kept required', () => {
+        it('requires scope of work', async () => {
+            const app = buildApplication({ scopeOfWork: null });
+            expect(await submitError(app)).toContain(
+                'Scope of work is required',
+            );
+        });
+
+        it('requires graduation year', async () => {
+            const app = buildApplication({ graduationYear: null });
+            expect(await submitError(app)).toContain(
+                'Graduation year is required',
+            );
+        });
+
+        it('requires domains', async () => {
+            const app = buildApplication({ domains: null });
+            expect(await submitError(app)).toContain('Domains is required');
+        });
+
+        it('requires education interests', async () => {
+            const app = buildApplication({ educationInterests: null });
+            expect(await submitError(app)).toContain(
+                'Education interests is required',
+            );
+        });
+
+        it('requires location', async () => {
+            const app = buildApplication({
+                applicant: {
+                    id: 'user-1',
+                    displayName: 'Alice',
+                    location: null,
+                    email: 'alice@example.com',
+                } as unknown as User,
+            });
+            expect(await submitError(app)).toContain('Location is required');
+        });
+    });
+
+    describe('DEVELOPER / DESIGNER — regression (must stay unchanged)', () => {
+        it('accepts a fully-populated developer application', async () => {
+            const app = buildDeveloper();
+            await submit(app);
+            expect(app.status).toBe(FellowshipApplicationStatus.SUBMITTED);
+        });
+
+        it('accepts a designer application without project github link or coding languages', async () => {
+            const app = buildDesigner({
+                projectGithubLink: null,
+                codingLanguages: null,
+                github: null,
+            });
+            await submit(app);
+            expect(app.status).toBe(FellowshipApplicationStatus.SUBMITTED);
+        });
+
+        it('requires the project github link for developers', async () => {
+            const app = buildDeveloper({ projectGithubLink: null });
+            expect(await submitError(app)).toContain(
+                'Project GitHub link is required',
+            );
+        });
+
+        it('requires a github username for developers', async () => {
+            const app = buildDeveloper({ github: null });
+            expect(await submitError(app)).toContain(
+                'A GitHub username is required for developer applications',
+            );
+        });
+
+        it('still requires the title and problem statement for developers', async () => {
+            const app = buildDeveloper({ title: null, problemStatement: null });
+            const message = await submitError(app);
+            expect(message).toContain('Title is required');
+            expect(message).toContain('Problem statement is required');
+        });
+
+        // Locks the exact, order-sensitive error output for developers so the
+        // requiredText restructure can't silently reorder or drop a check.
+        it('preserves the exact developer error order when everything is empty', async () => {
+            const app = buildApplication({
+                type: FellowshipType.DEVELOPER,
+                applicant: {
+                    id: 'user-1',
+                    displayName: 'Alice',
+                    location: null,
+                    email: 'alice@example.com',
+                } as unknown as User,
+                title: null,
+                problemStatement: null,
+                plan: null,
+                academicBackground: null,
+                professionalExperience: null,
+                bitcoinContributions: null,
+                bitcoinMotivation: null,
+                bitcoinOssGoal: null,
+                mentorName: null,
+                mentorContact: null,
+                mentorTestimonial: null,
+                projectName: null,
+                projectGithubLink: null,
+                graduationYear: null,
+                domains: null,
+                educationInterests: null,
+                codingLanguages: null,
+                github: null,
+                educationCategory: null,
+                city: null,
+                scopeOfWork: null,
+                educationCategoryOther: null,
+                cohortType: null,
+            });
+            const message = await submitError(app);
+            expect(message).toBe(
+                'Title is required; ' +
+                    'Problem statement is required; ' +
+                    'Plan is required; ' +
+                    'Academic background is required; ' +
+                    'Professional experience is required; ' +
+                    'Bitcoin contributions is required; ' +
+                    'Bitcoin motivation is required; ' +
+                    'Bitcoin OSS goal is required; ' +
+                    'Mentor name is required; ' +
+                    'Mentor contact is required; ' +
+                    'Mentor testimonial is required; ' +
+                    'Project name is required; ' +
+                    'Project GitHub link is required; ' +
+                    'Location is required; ' +
+                    'Graduation year is required; ' +
+                    'Domains is required; ' +
+                    'Education interests is required; ' +
+                    'Coding languages is required; ' +
+                    'A GitHub username is required for developer applications',
+            );
+        });
+    });
+});

--- a/src/fellowship-applications/fellowship-applications.service.ts
+++ b/src/fellowship-applications/fellowship-applications.service.ts
@@ -13,6 +13,7 @@ import {
     FellowshipApplicationStatus,
     FellowshipKind,
     FellowshipType,
+    EducationCategory,
     SortOrder,
     UserRole,
 } from '@/common/enum';
@@ -167,6 +168,11 @@ export class FellowshipApplicationsService {
             bitcoinOssGoal: emptyToNull(dto.bitcoinOssGoal),
             additionalInfo: emptyToNull(dto.additionalInfo),
             questionsForBitshala: emptyToNull(dto.questionsForBitshala),
+            educationCategory: dto.educationCategory ?? null,
+            cohortType: dto.cohortType ?? null,
+            city: emptyToNull(dto.city),
+            educationCategoryOther: emptyToNull(dto.educationCategoryOther),
+            scopeOfWork: emptyToNull(dto.scopeOfWork),
         });
 
         const saved = await this.applicationRepository.save(application);
@@ -233,6 +239,9 @@ export class FellowshipApplicationsService {
             'bitcoinOssGoal',
             'additionalInfo',
             'questionsForBitshala',
+            'city',
+            'educationCategoryOther',
+            'scopeOfWork',
         ] as const;
         for (const field of textFields) {
             if (dto[field] !== undefined) {
@@ -244,6 +253,12 @@ export class FellowshipApplicationsService {
         }
         if (dto.graduationYear !== undefined) {
             application.graduationYear = dto.graduationYear ?? null;
+        }
+        if (dto.educationCategory !== undefined) {
+            application.educationCategory = dto.educationCategory ?? null;
+        }
+        if (dto.cohortType !== undefined) {
+            application.cohortType = dto.cohortType ?? null;
         }
         const arrayFields = [
             'domains',
@@ -331,16 +346,30 @@ export class FellowshipApplicationsService {
         const isDeveloper = application.type === FellowshipType.DEVELOPER;
         const isEducator = application.type === FellowshipType.EDUCATOR;
 
-        const requiredText: [string, string | null][] = [
-            ['Title', application.title],
-            ['Problem statement', application.problemStatement],
+        const requiredText: [string, string | null][] = [];
+        // Title leads the developer/designer proposal. For educators the
+        // problem statement was streamlined out, and the title is applicant-
+        // entered only for Club/Other (checked in the educator block below) and
+        // auto-filled by the client for Cohort-TA/Meetup — so neither belongs
+        // in the shared required list.
+        if (!isEducator) {
+            requiredText.push(
+                ['Title', application.title],
+                ['Problem statement', application.problemStatement],
+            );
+        }
+        requiredText.push(
             ['Plan', application.plan],
             ['Academic background', application.academicBackground],
             ['Professional experience', application.professionalExperience],
             ['Bitcoin contributions', application.bitcoinContributions],
             ['Bitcoin motivation', application.bitcoinMotivation],
             ['Bitcoin OSS goal', application.bitcoinOssGoal],
-        ];
+        );
+        // The monthly scope-of-work breakdown is required for educators only.
+        if (isEducator) {
+            requiredText.push(['Scope of work', application.scopeOfWork]);
+        }
         // Mentor details, the mentor testimonial and the project name are
         // required for developers and designers but optional for educators.
         if (!isEducator) {
@@ -361,6 +390,42 @@ export class FellowshipApplicationsService {
         for (const [label, value] of requiredText) {
             if (!value || !value.trim()) {
                 errors.push(`${label} is required`);
+            }
+        }
+
+        // Education category and its conditional companions (educator only).
+        if (isEducator) {
+            if (!application.educationCategory) {
+                errors.push('Education category is required');
+            } else if (
+                application.educationCategory === EducationCategory.MEETUP &&
+                !application.city?.trim()
+            ) {
+                errors.push('City is required for a meetup');
+            } else if (
+                application.educationCategory === EducationCategory.COHORT_TA &&
+                !application.cohortType
+            ) {
+                errors.push(
+                    'A cohort is required when the category is Cohort TA',
+                );
+            } else if (
+                application.educationCategory === EducationCategory.OTHER &&
+                !application.educationCategoryOther?.trim()
+            ) {
+                errors.push(
+                    'A description is required when the category is Other',
+                );
+            }
+            // Title is applicant-entered for Club and Other (auto-filled by the
+            // client for Cohort-TA/Meetup, so not required from the applicant).
+            if (
+                (application.educationCategory === EducationCategory.CLUB ||
+                    application.educationCategory ===
+                        EducationCategory.OTHER) &&
+                !application.title?.trim()
+            ) {
+                errors.push('Title is required');
             }
         }
 

--- a/src/fellowships/fellowships.response.dto.ts
+++ b/src/fellowships/fellowships.response.dto.ts
@@ -2,6 +2,8 @@ import {
     FellowshipType,
     FellowshipStatus,
     FellowshipKind,
+    EducationCategory,
+    CohortType,
 } from '@/common/enum';
 import { Fellowship } from '@/entities/fellowship.entity';
 
@@ -26,6 +28,11 @@ export class FellowshipResponseDto {
     bitcoinOssGoal!: string | null;
     additionalInfo!: string | null;
     questionsForBitshala!: string | null;
+    educationCategory!: EducationCategory | null;
+    cohortType!: CohortType | null;
+    city!: string | null;
+    educationCategoryOther!: string | null;
+    scopeOfWork!: string | null;
     startDate!: string | null;
     endDate!: string | null;
     amountUsd!: string | null;
@@ -56,6 +63,11 @@ export class FellowshipResponseDto {
         this.bitcoinOssGoal = obj.bitcoinOssGoal;
         this.additionalInfo = obj.additionalInfo;
         this.questionsForBitshala = obj.questionsForBitshala;
+        this.educationCategory = obj.educationCategory;
+        this.cohortType = obj.cohortType;
+        this.city = obj.city;
+        this.educationCategoryOther = obj.educationCategoryOther;
+        this.scopeOfWork = obj.scopeOfWork;
         this.startDate = obj.startDate;
         this.endDate = obj.endDate;
         this.amountUsd = obj.amountUsd;
@@ -92,6 +104,11 @@ export class FellowshipResponseDto {
             bitcoinOssGoal: application.bitcoinOssGoal,
             additionalInfo: application.additionalInfo,
             questionsForBitshala: application.questionsForBitshala,
+            educationCategory: application.educationCategory,
+            cohortType: application.cohortType,
+            city: application.city,
+            educationCategoryOther: application.educationCategoryOther,
+            scopeOfWork: application.scopeOfWork,
             startDate: fellowship.startDate?.toISOString() ?? null,
             endDate: fellowship.endDate?.toISOString() ?? null,
             amountUsd: fellowship.amountUsd,


### PR DESCRIPTION
Reworks the **education** (`EDUCATOR`) fellowship application into a category-based questionnaire. Education fellowships cover TAing a cohort, running meetups, running clubs, or an "other" activity — each needs different information than the generic developer/designer proposal.

Developer and designer applications are unchanged.

## What changed
- **New category** (`educationCategory`): `MEETUP` / `CLUB` / `COHORT_TA` / `OTHER`, with conditional companions — `city` (meetup), `cohortType` (course to TA), `educationCategoryOther` (free-form for "other") — plus a `scopeOfWork` monthly breakdown. Reuses the existing `plan`, `questionsForBitshala`, background/experience and Bitcoin-OSS fields.
- **Storage**: five new nullable columns on `fellowship_application`, with the accompanying migration.
- **Submit rules** (educators): require category; `city` for meetups; `cohortType` for cohort-TA; `educationCategoryOther` for other; `scopeOfWork`; and a `title` for club/other (auto-filled by the client for meetup/cohort-TA). `problemStatement` is dropped for educators; graduation year, domains and education interests are kept.
- **Responses**: the new fields are surfaced on the proposal read and on accepted-fellowship responses.
- Adds unit tests for the educator submit rules, plus a regression lock on the (unchanged) developer/designer error output.

## Follow-ups
- Run `npm run migration:run` in each environment — the migration adds two enum types + five columns and has not been executed against a live DB here.
- The applicant-facing form lives in the frontend repo and is being mirrored separately (category dropdown, city input, and title auto-fill: `TA in <course> cohort` / `Meetup in <city>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)