### PR TITLE
feat: accept pre-signed contract + W-8BEN directly on application accept

### DIFF
--- a/assets/mail-templates/fellowship-application-accepted-no-documents.html.eta
+++ b/assets/mail-templates/fellowship-application-accepted-no-documents.html.eta
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Welcome to the Bitshala Fellowship</title>
+</head>
+<body style="margin:0; padding:0; background-color:#111111; font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;">
+
+  <div style="display:none; max-height:0; overflow:hidden; mso-hide:all; visibility:hidden; opacity:0; color:transparent;">
+    Your Bitshala Fellowship is confirmed — your contract and tax form are already on file.
+    &#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;&#8199;
+  </div>
+
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#111111; padding:24px 0;">
+    <tr>
+      <td align="center">
+
+        <table width="600" cellpadding="0" cellspacing="0" border="0" style="background-color:#1b1b1b; border-radius:16px; overflow:hidden;">
+
+          <tr>
+            <td align="center" style="background-color:#000000; padding:24px 24px 20px 24px;">
+              <h1 style="margin:0; font-size:24px; color:#ffffff; font-weight:700;">
+                Welcome <%~ it.userName %>!
+              </h1>
+              <p style="margin:8px 0 0 0; font-size:14px; color:#f9b233; font-weight:500;">
+                Your <%~ it.fellowshipType %> Fellowship Application Has Been Accepted
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:24px 32px 8px 32px; color:#eaeaea; font-size:14px; line-height:1.6;">
+              <p style="margin:0 0 12px 0;">Dear <%~ it.userName %>,</p>
+              <p style="margin:0 0 12px 0;">
+                We are thrilled to inform you that you have been selected for the
+                <strong style="color:#f9b233;">Bitshala <%~ it.fellowshipType %> Fellowship</strong>!
+                We're excited to see your impact and contributions and look forward to
+                working with you over the months ahead.
+              </p>
+              <p style="margin:0;">
+                Your signed contract and W-8BEN form are already on file, so there's
+                nothing further you need to upload — you're all set on the paperwork.
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:24px 32px 0 32px;">
+              <div style="height:1px; background-color:#2e2e2e; line-height:1px; font-size:1px;">&nbsp;</div>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:20px 32px 8px 32px;">
+              <h2 style="margin:0 0 16px 0; font-size:18px; color:#ffd580;">Next Steps</h2>
+
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#262626; border-radius:12px;">
+                <tr>
+                  <td width="48" valign="top" style="padding:16px 0 16px 16px;">
+                    <div style="width:32px; height:32px; line-height:32px; text-align:center; border-radius:999px; background-color:#f7931a; color:#000000; font-weight:700; font-size:14px;">1</div>
+                  </td>
+                  <td style="padding:16px 16px 16px 12px; color:#eaeaea; font-size:13px; line-height:1.6;">
+                    <strong style="color:#ffffff;">Share Account Details.</strong>
+                    Monthly payments are processed through <strong>Skydo</strong>.
+                    You'll receive a separate email from Skydo with a form for your
+                    account and contact info — please fill it in.
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:24px 32px 0 32px;">
+              <div style="height:1px; background-color:#2e2e2e; line-height:1px; font-size:1px;">&nbsp;</div>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:20px 32px 32px 32px; color:#eaeaea; font-size:13px; line-height:1.6;">
+              <p style="margin:0 0 12px 0;">
+                If you have any questions or need clarification, email us at
+                <a href="mailto:fellowship@bitshala.org" style="color:#f9b233; text-decoration:underline;">fellowship@bitshala.org</a>
+                — we're here to support you every step of the way.
+              </p>
+              <p style="margin:0;">Welcome aboard, and we look forward to achieving great things together!</p>
+              <p style="margin:16px 0 0 0; color:#9a9a9a;">— Team Bitshala</p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/assets/mail-templates/fellowship-application-accepted-no-documents.text.eta
+++ b/assets/mail-templates/fellowship-application-accepted-no-documents.text.eta
@@ -1,0 +1,24 @@
+Welcome <%~ it.userName %>!
+
+Your <%~ it.fellowshipType %> Fellowship Application Has Been Accepted
+
+Dear <%~ it.userName %>,
+
+We are thrilled to inform you that you have been selected for the Bitshala <%~ it.fellowshipType %> Fellowship! We're excited to see your impact and contributions and look forward to working with you over the months ahead.
+
+Your signed contract and W-8BEN form are already on file, so there's nothing further you need to upload — you're all set on the paperwork.
+
+---
+
+Next Steps
+
+1. Share Account Details
+   Monthly payments are processed through Skydo. You'll receive a separate email from Skydo with a form for your account and contact info — please fill it in.
+
+---
+
+If you have any questions or need clarification, email us at fellowship@bitshala.org — we're here to support you every step of the way.
+
+Welcome aboard, and we look forward to achieving great things together!
+
+— Team Bitshala

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -131,6 +131,17 @@ export enum FellowshipDocumentStatus {
     REJECTED = 'REJECTED',
 }
 
+// How the contract is provided when an admin accepts an application.
+// UNSIGNED (default): the admin uploads the Bitshala-signed unsigned contract and
+// the fellow signs it offline, then uploads the signed contract + W-8BEN for
+// review. PRESIGNED: the contract was signed out of band, so the admin uploads
+// the already-signed contract + W-8BEN directly and the fellow upload/review
+// step is skipped.
+export enum AcceptContractMode {
+    UNSIGNED = 'UNSIGNED',
+    PRESIGNED = 'PRESIGNED',
+}
+
 export enum FellowshipReportStatus {
     DRAFT = 'DRAFT',
     SUBMITTED = 'SUBMITTED',

--- a/src/fellowship-applications/fellowship-applications.controller.ts
+++ b/src/fellowship-applications/fellowship-applications.controller.ts
@@ -10,12 +10,12 @@ import {
     Patch,
     Post,
     Query,
-    UploadedFile,
+    UploadedFiles,
     UseInterceptors,
     UsePipes,
     ValidationPipe,
 } from '@nestjs/common';
-import { FileInterceptor } from '@nestjs/platform-express';
+import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import {
     ApiBearerAuth,
     ApiConsumes,
@@ -24,7 +24,10 @@ import {
     ApiTags,
 } from '@nestjs/swagger';
 import { MAX_DOCUMENT_BYTES, pdfFileFilter } from '@/common/upload';
-import { FellowshipApplicationsService } from '@/fellowship-applications/fellowship-applications.service';
+import {
+    FellowshipApplicationsService,
+    ReviewApplicationFiles,
+} from '@/fellowship-applications/fellowship-applications.service';
 import {
     CreateFellowshipApplicationRequestDto,
     FellowshipApplicationSortBy,
@@ -167,22 +170,29 @@ export class FellowshipApplicationsController {
     @Patch(':id/review')
     @ApiOperation({
         summary:
-            'Review a fellowship application (admin). Accepting is multipart and carries the Bitshala-signed unsigned-contract PDF as `file`.',
+            'Review a fellowship application (admin). Accepting is multipart: with contractMode=UNSIGNED (default) send the Bitshala unsigned contract as `file`; with contractMode=PRESIGNED send an already-signed `signedContract` plus `w8ben` to skip the fellow upload/review flow.',
     })
     @ApiConsumes('multipart/form-data', 'application/json')
     @Roles(UserRole.ADMIN)
     @UseInterceptors(
-        FileInterceptor('file', {
-            limits: { fileSize: MAX_DOCUMENT_BYTES },
-            fileFilter: pdfFileFilter,
-        }),
+        FileFieldsInterceptor(
+            [
+                { name: 'file', maxCount: 1 },
+                { name: 'signedContract', maxCount: 1 },
+                { name: 'w8ben', maxCount: 1 },
+            ],
+            {
+                limits: { fileSize: MAX_DOCUMENT_BYTES },
+                fileFilter: pdfFileFilter,
+            },
+        ),
     )
     async reviewApplication(
         @Param('id', new ParseUUIDPipe()) id: string,
         @GetUser() user: User,
         @Body() body: ReviewFellowshipApplicationRequestDto,
-        @UploadedFile() file?: Express.Multer.File,
+        @UploadedFiles() files: ReviewApplicationFiles,
     ): Promise<FellowshipApplicationResponseDto> {
-        return this.service.reviewApplication(id, user, body, file);
+        return this.service.reviewApplication(id, user, body, files);
     }
 }

--- a/src/fellowship-applications/fellowship-applications.request.dto.ts
+++ b/src/fellowship-applications/fellowship-applications.request.dto.ts
@@ -19,6 +19,7 @@ import {
     FellowshipType,
     FellowshipApplicationStatus,
     FellowshipKind,
+    AcceptContractMode,
     SortOrder,
     EducationCategory,
     CohortType,
@@ -271,9 +272,19 @@ export class ReviewFellowshipApplicationRequestDto {
     @IsEnum(FellowshipKind)
     kind?: FellowshipKind;
 
-    // Accepting an application is a multipart request that also carries the
-    // Bitshala-signed unsigned-contract PDF (validated in the controller/service),
-    // which replaces the old `driveFolderUrl` field.
+    // How the contract is provided on accept. Only consumed when status is
+    // ACCEPTED; defaults to UNSIGNED. UNSIGNED expects the Bitshala-signed
+    // unsigned contract as the `file` part; PRESIGNED expects an already-signed
+    // contract as `signedContract` plus the tax form as `w8ben`, skipping the
+    // fellow's upload/review step.
+    @IsOptional()
+    @IsEnum(AcceptContractMode)
+    contractMode?: AcceptContractMode;
+
+    // Accepting an application is a multipart request. In UNSIGNED mode it carries
+    // the Bitshala-signed unsigned-contract PDF as `file`; in PRESIGNED mode it
+    // carries `signedContract` + `w8ben` instead. File parts are validated in the
+    // controller/service, not here.
 }
 
 export enum FellowshipApplicationSortBy {

--- a/src/fellowship-applications/fellowship-applications.service.spec.ts
+++ b/src/fellowship-applications/fellowship-applications.service.spec.ts
@@ -1,15 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { FellowshipApplicationsService } from '@/fellowship-applications/fellowship-applications.service';
+import {
+    FellowshipApplicationsService,
+    ReviewApplicationFiles,
+} from '@/fellowship-applications/fellowship-applications.service';
+import { ReviewFellowshipApplicationRequestDto } from '@/fellowship-applications/fellowship-applications.request.dto';
 import { FellowshipApplication } from '@/entities/fellowship-application.entity';
 import { User } from '@/entities/user.entity';
 import { MailService } from '@/mail/mail.service';
 import { GitHubClassroomClient } from '@/github-classroom/client/github-classroom.client';
 import { FellowshipDocumentsService } from '@/fellowship-documents/fellowship-documents.service';
 import {
+    AcceptContractMode,
     CohortType,
     EducationCategory,
     FellowshipApplicationStatus,
+    FellowshipKind,
     FellowshipType,
 } from '@/common/enum';
 
@@ -434,6 +440,228 @@ describe('FellowshipApplicationsService — submit validation', () => {
                     'Coding languages is required; ' +
                     'A GitHub username is required for developer applications',
             );
+        });
+    });
+});
+
+// Exercises reviewApplication's accept dispatch: which contract documents are
+// required, what gets passed to provisioning, and which acceptance email is sent
+// for each contractMode. Provisioning itself is mocked (covered separately in the
+// documents service spec).
+describe('FellowshipApplicationsService — review (accept) contract modes', () => {
+    let service: FellowshipApplicationsService;
+
+    const applicationRepository = {
+        findOne: jest.fn(),
+        save: jest.fn(),
+    };
+    const documentsService = {
+        provisionAcceptedApplication: jest.fn(),
+    };
+    const mailService = {
+        sendFellowshipApplicationAcceptedEmail: jest.fn(),
+        sendFellowshipApplicationAcceptedNoDocumentsEmail: jest.fn(),
+        sendFellowshipApplicationRejectedEmail: jest.fn(),
+        sendFellowshipApplicationChangesRequestedEmail: jest.fn(),
+    };
+
+    const reviewer = {
+        id: 'admin-1',
+        displayName: 'Admin',
+        email: 'admin@example.com',
+    } as unknown as User;
+
+    const applicant = {
+        id: 'user-1',
+        displayName: 'Alice',
+        email: 'alice@example.com',
+    } as unknown as User;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                FellowshipApplicationsService,
+                {
+                    provide: getRepositoryToken(FellowshipApplication),
+                    useValue: applicationRepository,
+                },
+                { provide: getRepositoryToken(User), useValue: {} },
+                { provide: MailService, useValue: mailService },
+                { provide: GitHubClassroomClient, useValue: {} },
+                {
+                    provide: FellowshipDocumentsService,
+                    useValue: documentsService,
+                },
+            ],
+        }).compile();
+
+        service = module.get(FellowshipApplicationsService);
+        applicationRepository.save.mockImplementation(
+            async (a: FellowshipApplication) => a,
+        );
+        documentsService.provisionAcceptedApplication.mockResolvedValue({
+            id: 'fellowship-1',
+        });
+        mailService.sendFellowshipApplicationAcceptedEmail.mockResolvedValue(
+            undefined,
+        );
+        mailService.sendFellowshipApplicationAcceptedNoDocumentsEmail.mockResolvedValue(
+            undefined,
+        );
+    });
+
+    afterEach(() => jest.resetAllMocks());
+
+    function submittedApplication(): FellowshipApplication {
+        return {
+            id: 'app-1',
+            type: FellowshipType.DEVELOPER,
+            status: FellowshipApplicationStatus.SUBMITTED,
+            applicant,
+            reviewedBy: null,
+            reviewerRemarks: null,
+            driveFolderId: null,
+            fellowship: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        } as unknown as FellowshipApplication;
+    }
+
+    // A minimal stand-in for a multipart PDF part. Content is irrelevant here
+    // because provisioning (which runs the %PDF- check) is mocked.
+    function pdf(originalname: string): Express.Multer.File {
+        return {
+            buffer: Buffer.from('%PDF-1.4 test'),
+            size: 13,
+            originalname,
+            mimetype: 'application/pdf',
+        } as unknown as Express.Multer.File;
+    }
+
+    async function review(
+        dto: ReviewFellowshipApplicationRequestDto,
+        files: ReviewApplicationFiles = {},
+    ): Promise<void> {
+        applicationRepository.findOne.mockResolvedValue(submittedApplication());
+        await service.reviewApplication('app-1', reviewer, dto, files);
+    }
+
+    async function reviewError(
+        dto: ReviewFellowshipApplicationRequestDto,
+        files: ReviewApplicationFiles = {},
+    ): Promise<string> {
+        applicationRepository.findOne.mockResolvedValue(submittedApplication());
+        try {
+            await service.reviewApplication('app-1', reviewer, dto, files);
+        } catch (e) {
+            return (e as Error).message;
+        }
+        throw new Error('Expected reviewApplication to throw, but it resolved');
+    }
+
+    describe('PRESIGNED', () => {
+        it('requires the signed contract', async () => {
+            const message = await reviewError(
+                {
+                    status: FellowshipApplicationStatus.ACCEPTED,
+                    contractMode: AcceptContractMode.PRESIGNED,
+                },
+                { w8ben: [pdf('w8ben.pdf')] },
+            );
+            expect(message).toContain('signed contract');
+            expect(
+                documentsService.provisionAcceptedApplication,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('requires the W-8BEN', async () => {
+            const message = await reviewError(
+                {
+                    status: FellowshipApplicationStatus.ACCEPTED,
+                    contractMode: AcceptContractMode.PRESIGNED,
+                },
+                { signedContract: [pdf('signed.pdf')] },
+            );
+            expect(message).toContain('W-8BEN');
+            expect(
+                documentsService.provisionAcceptedApplication,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('provisions with both documents and sends the no-documents email', async () => {
+            const signedContract = pdf('signed.pdf');
+            const w8ben = pdf('w8ben.pdf');
+            await review(
+                {
+                    status: FellowshipApplicationStatus.ACCEPTED,
+                    contractMode: AcceptContractMode.PRESIGNED,
+                },
+                { signedContract: [signedContract], w8ben: [w8ben] },
+            );
+
+            expect(
+                documentsService.provisionAcceptedApplication,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({ id: 'app-1' }),
+                reviewer,
+                {
+                    mode: AcceptContractMode.PRESIGNED,
+                    signedContract,
+                    w8ben,
+                },
+                FellowshipKind.FELLOWSHIP,
+            );
+            expect(
+                mailService.sendFellowshipApplicationAcceptedNoDocumentsEmail,
+            ).toHaveBeenCalledWith(
+                'alice@example.com',
+                'Alice',
+                FellowshipType.DEVELOPER,
+            );
+            expect(
+                mailService.sendFellowshipApplicationAcceptedEmail,
+            ).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('UNSIGNED (default)', () => {
+        it('requires the unsigned contract', async () => {
+            const message = await reviewError(
+                { status: FellowshipApplicationStatus.ACCEPTED },
+                {},
+            );
+            expect(message).toContain('unsigned-contract');
+            expect(
+                documentsService.provisionAcceptedApplication,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('provisions with the unsigned contract and sends the standard email', async () => {
+            const file = pdf('unsigned.pdf');
+            await review(
+                { status: FellowshipApplicationStatus.ACCEPTED },
+                { file: [file] },
+            );
+
+            expect(
+                documentsService.provisionAcceptedApplication,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({ id: 'app-1' }),
+                reviewer,
+                { mode: AcceptContractMode.UNSIGNED, unsignedContract: file },
+                FellowshipKind.FELLOWSHIP,
+            );
+            expect(
+                mailService.sendFellowshipApplicationAcceptedEmail,
+            ).toHaveBeenCalledWith(
+                'alice@example.com',
+                'Alice',
+                FellowshipType.DEVELOPER,
+                'fellowship-1',
+            );
+            expect(
+                mailService.sendFellowshipApplicationAcceptedNoDocumentsEmail,
+            ).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/fellowship-applications/fellowship-applications.service.ts
+++ b/src/fellowship-applications/fellowship-applications.service.ts
@@ -10,6 +10,7 @@ import { Brackets, In, Repository } from 'typeorm';
 import { FellowshipApplication } from '@/entities/fellowship-application.entity';
 import { User } from '@/entities/user.entity';
 import {
+    AcceptContractMode,
     FellowshipApplicationStatus,
     FellowshipKind,
     FellowshipType,
@@ -32,7 +33,10 @@ import { PaginatedDataDto, PaginatedQueryDto } from '@/common/dto';
 import { escapeLikePattern } from '@/common/common';
 import { GitHubClassroomClient } from '@/github-classroom/client/github-classroom.client';
 import { MailService } from '@/mail/mail.service';
-import { FellowshipDocumentsService } from '@/fellowship-documents/fellowship-documents.service';
+import {
+    AcceptedContract,
+    FellowshipDocumentsService,
+} from '@/fellowship-documents/fellowship-documents.service';
 import {
     GITHUB_USERNAME_RE,
     LINK_LIMIT,
@@ -52,6 +56,16 @@ const APPLICATION_SORT_COLUMNS: Record<FellowshipApplicationSortBy, string> = {
     [FellowshipApplicationSortBy.CREATED_AT]: 'application.createdAt',
     [FellowshipApplicationSortBy.UPDATED_AT]: 'application.updatedAt',
 };
+
+// Multipart file parts accepted on the review (accept) endpoint. `file` is the
+// unsigned contract for the standard flow; `signedContract` + `w8ben` are the
+// pre-signed documents for the skip-signing flow. Each field is an array because
+// it comes from FileFieldsInterceptor.
+export interface ReviewApplicationFiles {
+    file?: Express.Multer.File[];
+    signedContract?: Express.Multer.File[];
+    w8ben?: Express.Multer.File[];
+}
 
 @Injectable()
 export class FellowshipApplicationsService {
@@ -646,7 +660,7 @@ export class FellowshipApplicationsService {
         id: string,
         reviewer: User,
         dto: ReviewFellowshipApplicationRequestDto,
-        file?: Express.Multer.File,
+        files: ReviewApplicationFiles = {},
     ): Promise<FellowshipApplicationResponseDto> {
         const application = await this.applicationRepository.findOne({
             where: { id },
@@ -698,10 +712,45 @@ export class FellowshipApplicationsService {
             );
         }
 
-        if (dto.status === FellowshipApplicationStatus.ACCEPTED && !file) {
-            throw new BadRequestException(
-                'The Bitshala-signed unsigned-contract PDF is required when accepting an application',
-            );
+        // Resolve the accept-time contract documents. In UNSIGNED mode (default)
+        // the admin uploads the Bitshala unsigned contract as `file`; in PRESIGNED
+        // mode they upload an already-signed `signedContract` plus `w8ben` and the
+        // fellow's upload/review step is skipped. File presence is validated here
+        // (files are multipart parts, not DTO fields).
+        const contractMode = dto.contractMode ?? AcceptContractMode.UNSIGNED;
+        const unsignedContract = files.file?.[0];
+        const signedContract = files.signedContract?.[0];
+        const w8ben = files.w8ben?.[0];
+
+        let acceptedContract: AcceptedContract | undefined;
+        if (dto.status === FellowshipApplicationStatus.ACCEPTED) {
+            if (contractMode === AcceptContractMode.PRESIGNED) {
+                if (!signedContract) {
+                    throw new BadRequestException(
+                        'A signed contract PDF (`signedContract`) is required when accepting with a pre-signed contract',
+                    );
+                }
+                if (!w8ben) {
+                    throw new BadRequestException(
+                        'A W-8BEN PDF (`w8ben`) is required when accepting with a pre-signed contract',
+                    );
+                }
+                acceptedContract = {
+                    mode: AcceptContractMode.PRESIGNED,
+                    signedContract,
+                    w8ben,
+                };
+            } else {
+                if (!unsignedContract) {
+                    throw new BadRequestException(
+                        'The Bitshala-signed unsigned-contract PDF is required when accepting an application',
+                    );
+                }
+                acceptedContract = {
+                    mode: AcceptContractMode.UNSIGNED,
+                    unsignedContract,
+                };
+            }
         }
 
         application.status = dto.status;
@@ -711,16 +760,16 @@ export class FellowshipApplicationsService {
         }
 
         // On accept, provisioning persists the application (status/reviewedBy +
-        // driveFolderId), creates the Fellowship and the three document rows, and
-        // uploads the unsigned contract — all in one transaction. Other outcomes
-        // are a simple status save.
+        // driveFolderId), creates the Fellowship and the document rows, and uploads
+        // the contract document(s) — all in one transaction. Other outcomes are a
+        // simple status save.
         let acceptedFellowshipId: string | undefined;
         if (dto.status === FellowshipApplicationStatus.ACCEPTED) {
             const fellowship =
                 await this.documentsService.provisionAcceptedApplication(
                     application,
                     reviewer,
-                    file!,
+                    acceptedContract!,
                     dto.kind ?? FellowshipKind.FELLOWSHIP,
                 );
             acceptedFellowshipId = fellowship.id;
@@ -732,12 +781,22 @@ export class FellowshipApplicationsService {
         if (applicant.email) {
             try {
                 if (dto.status === FellowshipApplicationStatus.ACCEPTED) {
-                    await this.mailService.sendFellowshipApplicationAcceptedEmail(
-                        applicant.email,
-                        applicant.displayName,
-                        application.type,
-                        acceptedFellowshipId!,
-                    );
+                    if (contractMode === AcceptContractMode.PRESIGNED) {
+                        // Signed contract + W-8BEN are already on file; the fellow
+                        // has nothing to upload, so send the no-documents variant.
+                        await this.mailService.sendFellowshipApplicationAcceptedNoDocumentsEmail(
+                            applicant.email,
+                            applicant.displayName,
+                            application.type,
+                        );
+                    } else {
+                        await this.mailService.sendFellowshipApplicationAcceptedEmail(
+                            applicant.email,
+                            applicant.displayName,
+                            application.type,
+                            acceptedFellowshipId!,
+                        );
+                    }
                 } else if (
                     dto.status === FellowshipApplicationStatus.REJECTED
                 ) {

--- a/src/fellowship-documents/fellowship-documents.service.spec.ts
+++ b/src/fellowship-documents/fellowship-documents.service.spec.ts
@@ -1,0 +1,245 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConflictException } from '@nestjs/common';
+import { EntityManager } from 'typeorm';
+import {
+    AcceptedContract,
+    FellowshipDocumentsService,
+} from '@/fellowship-documents/fellowship-documents.service';
+import { FellowshipDocument } from '@/entities/fellowship-document.entity';
+import { Fellowship } from '@/entities/fellowship.entity';
+import { FellowshipApplication } from '@/entities/fellowship-application.entity';
+import { GoogleDriveService } from '@/google-drive/google-drive.service';
+import { DbTransactionService } from '@/db-transaction/db-transaction.service';
+import { MailService } from '@/mail/mail.service';
+import { User } from '@/entities/user.entity';
+import {
+    AcceptContractMode,
+    FellowshipDocumentStatus,
+    FellowshipDocumentType,
+    FellowshipStatus,
+    FellowshipType,
+} from '@/common/enum';
+
+// Covers accept-time provisioning for both contract modes: which Drive uploads
+// happen, which document rows are written (and their statuses), the resulting
+// fellowship status, idempotency, and best-effort folder cleanup on failure.
+describe('FellowshipDocumentsService — provisionAcceptedApplication', () => {
+    let service: FellowshipDocumentsService;
+
+    const drive = {
+        rootFolderId: 'root-folder',
+        createFolder: jest.fn(),
+        uploadFile: jest.fn(),
+        deleteFolder: jest.fn(),
+        deleteFile: jest.fn(),
+    };
+
+    // A mock EntityManager whose create() echoes its data so tests can inspect
+    // exactly what would be persisted, and whose save() is a passthrough.
+    const manager = {
+        findOne: jest.fn(),
+        save: jest.fn(),
+        create: jest.fn((_entity: unknown, data: unknown) => data),
+        find: jest.fn(),
+        update: jest.fn(),
+    };
+
+    const dbTransactionService = {
+        execute: jest.fn((fn: (m: EntityManager) => Promise<unknown>) =>
+            fn(manager as unknown as EntityManager),
+        ),
+    };
+
+    const reviewer = { id: 'admin-1', displayName: 'Admin' } as unknown as User;
+    const applicant = {
+        id: 'user-1',
+        displayName: 'Alice',
+    } as unknown as User;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                FellowshipDocumentsService,
+                {
+                    provide: getRepositoryToken(FellowshipDocument),
+                    useValue: {},
+                },
+                { provide: getRepositoryToken(Fellowship), useValue: {} },
+                { provide: GoogleDriveService, useValue: drive },
+                {
+                    provide: DbTransactionService,
+                    useValue: dbTransactionService,
+                },
+                { provide: MailService, useValue: {} },
+            ],
+        }).compile();
+
+        service = module.get(FellowshipDocumentsService);
+
+        // afterEach runs jest.resetAllMocks(), which clears implementations too,
+        // so (re)establish every stubbed behavior here in beforeEach.
+        dbTransactionService.execute.mockImplementation(
+            (fn: (m: EntityManager) => Promise<unknown>) =>
+                fn(manager as unknown as EntityManager),
+        );
+        manager.create.mockImplementation(
+            (_entity: unknown, data: unknown) => data,
+        );
+        manager.save.mockImplementation(async (_e: unknown, x: unknown) => x);
+        drive.createFolder.mockResolvedValue('folder-1');
+        drive.deleteFolder.mockResolvedValue(undefined);
+        // Lock read: an unprovisioned application by default.
+        manager.findOne.mockResolvedValue({ id: 'app-1', driveFolderId: null });
+    });
+
+    afterEach(() => jest.resetAllMocks());
+
+    function application(): FellowshipApplication {
+        return {
+            id: 'app-1',
+            type: FellowshipType.DEVELOPER,
+            applicant,
+            driveFolderId: null,
+        } as unknown as FellowshipApplication;
+    }
+
+    // A minimal stand-in for a multipart PDF part; the buffer passes the %PDF-
+    // magic-byte check in assertValidPdf.
+    function pdf(originalname: string): Express.Multer.File {
+        return {
+            buffer: Buffer.from('%PDF-1.4 test'),
+            size: 13,
+            originalname,
+            mimetype: 'application/pdf',
+        } as unknown as Express.Multer.File;
+    }
+
+    // The single save() payload for a given entity class.
+    function saved(entityClass: unknown): unknown {
+        const call = manager.save.mock.calls.find((c) => c[0] === entityClass);
+        return call?.[1];
+    }
+
+    function byType(
+        documents: FellowshipDocument[],
+    ): Record<string, FellowshipDocument> {
+        return Object.fromEntries(documents.map((d) => [d.type, d]));
+    }
+
+    describe('PRESIGNED', () => {
+        const contract = (): AcceptedContract => ({
+            mode: AcceptContractMode.PRESIGNED,
+            signedContract: pdf('signed.pdf'),
+            w8ben: pdf('w8ben.pdf'),
+        });
+
+        it('uploads both files, writes two APPROVED docs, and lands the fellowship in DOCUMENTS_APPROVED', async () => {
+            drive.uploadFile
+                .mockResolvedValueOnce('signed-file')
+                .mockResolvedValueOnce('w8ben-file');
+
+            const fellowship = (await service.provisionAcceptedApplication(
+                application(),
+                reviewer,
+                contract(),
+            )) as Fellowship;
+
+            expect(drive.createFolder).toHaveBeenCalledTimes(1);
+            expect(drive.uploadFile).toHaveBeenCalledTimes(2);
+
+            expect(fellowship).toMatchObject({
+                status: FellowshipStatus.DOCUMENTS_APPROVED,
+            });
+            expect(saved(Fellowship)).toMatchObject({
+                status: FellowshipStatus.DOCUMENTS_APPROVED,
+            });
+
+            const documents = saved(FellowshipDocument) as FellowshipDocument[];
+            expect(documents).toHaveLength(2);
+            const docs = byType(documents);
+            expect(
+                docs[FellowshipDocumentType.UNSIGNED_CONTRACT],
+            ).toBeUndefined();
+            expect(docs[FellowshipDocumentType.SIGNED_CONTRACT]).toMatchObject({
+                status: FellowshipDocumentStatus.APPROVED,
+                driveFileId: 'signed-file',
+                uploadedBy: reviewer,
+                reviewedBy: reviewer,
+            });
+            expect(docs[FellowshipDocumentType.W8BEN]).toMatchObject({
+                status: FellowshipDocumentStatus.APPROVED,
+                driveFileId: 'w8ben-file',
+                uploadedBy: reviewer,
+                reviewedBy: reviewer,
+            });
+        });
+
+        it('is idempotent: an already-provisioned application throws Conflict and creates no folder', async () => {
+            manager.findOne.mockResolvedValue({
+                id: 'app-1',
+                driveFolderId: 'existing-folder',
+            });
+
+            await expect(
+                service.provisionAcceptedApplication(
+                    application(),
+                    reviewer,
+                    contract(),
+                ),
+            ).rejects.toBeInstanceOf(ConflictException);
+            expect(drive.createFolder).not.toHaveBeenCalled();
+        });
+
+        it('best-effort deletes the folder when an upload fails', async () => {
+            drive.uploadFile
+                .mockResolvedValueOnce('signed-file')
+                .mockRejectedValueOnce(new Error('drive down'));
+
+            await expect(
+                service.provisionAcceptedApplication(
+                    application(),
+                    reviewer,
+                    contract(),
+                ),
+            ).rejects.toThrow('drive down');
+            expect(drive.deleteFolder).toHaveBeenCalledWith('folder-1');
+        });
+    });
+
+    describe('UNSIGNED', () => {
+        it('uploads the unsigned contract and seeds two AWAITING_UPLOAD fellow docs (AWAITING_DOCUMENTS)', async () => {
+            drive.uploadFile.mockResolvedValueOnce('unsigned-file');
+
+            const fellowship = (await service.provisionAcceptedApplication(
+                application(),
+                reviewer,
+                {
+                    mode: AcceptContractMode.UNSIGNED,
+                    unsignedContract: pdf('unsigned.pdf'),
+                },
+            )) as Fellowship;
+
+            expect(drive.uploadFile).toHaveBeenCalledTimes(1);
+            expect(fellowship).toMatchObject({
+                status: FellowshipStatus.AWAITING_DOCUMENTS,
+            });
+
+            const documents = saved(FellowshipDocument) as FellowshipDocument[];
+            expect(documents).toHaveLength(3);
+            const docs = byType(documents);
+            expect(
+                docs[FellowshipDocumentType.UNSIGNED_CONTRACT],
+            ).toMatchObject({
+                status: FellowshipDocumentStatus.APPROVED,
+                driveFileId: 'unsigned-file',
+            });
+            expect(docs[FellowshipDocumentType.SIGNED_CONTRACT]).toMatchObject({
+                status: FellowshipDocumentStatus.AWAITING_UPLOAD,
+            });
+            expect(docs[FellowshipDocumentType.W8BEN]).toMatchObject({
+                status: FellowshipDocumentStatus.AWAITING_UPLOAD,
+            });
+        });
+    });
+});

--- a/src/fellowship-documents/fellowship-documents.service.ts
+++ b/src/fellowship-documents/fellowship-documents.service.ts
@@ -14,6 +14,7 @@ import { Fellowship } from '@/entities/fellowship.entity';
 import { FellowshipApplication } from '@/entities/fellowship-application.entity';
 import { User } from '@/entities/user.entity';
 import {
+    AcceptContractMode,
     FellowshipDocumentStatus,
     FellowshipDocumentType,
     FellowshipKind,
@@ -47,6 +48,26 @@ export interface DownloadedDocument {
     mimeType: string;
 }
 
+/**
+ * The contract documents supplied when an admin accepts an application.
+ *
+ * - UNSIGNED: the standard flow — the admin provides the Bitshala-signed unsigned
+ *   contract; the fellow later uploads the signed contract + W-8BEN for review.
+ * - PRESIGNED: the contract was signed out of band, so the admin provides the
+ *   already-signed contract and the W-8BEN directly and the fellow upload/review
+ *   step is skipped.
+ */
+export type AcceptedContract =
+    | {
+          mode: AcceptContractMode.UNSIGNED;
+          unsignedContract: Express.Multer.File;
+      }
+    | {
+          mode: AcceptContractMode.PRESIGNED;
+          signedContract: Express.Multer.File;
+          w8ben: Express.Multer.File;
+      };
+
 @Injectable()
 export class FellowshipDocumentsService {
     private readonly logger = new Logger(FellowshipDocumentsService.name);
@@ -63,11 +84,19 @@ export class FellowshipDocumentsService {
 
     /**
      * Accept-time provisioning, run from the application review flow. Lazily
-     * creates the per-application Drive folder, streams in the unsigned contract,
-     * and writes — in one transaction — the accepted application (with its new
-     * `driveFolderId`), the `Fellowship` (AWAITING_DOCUMENTS) and the three
-     * document rows. Drive happens first; on DB failure the folder is best-effort
-     * deleted so we never leak an orphan.
+     * creates the per-application Drive folder, streams in the contract
+     * document(s), and writes — in one transaction — the accepted application
+     * (with its new `driveFolderId`), the `Fellowship` and the document rows.
+     * Drive happens first; on DB failure the folder is best-effort deleted so we
+     * never leak an orphan.
+     *
+     * The document set and starting statuses depend on `contract.mode`:
+     * - UNSIGNED: uploads the Bitshala unsigned contract (APPROVED) and seeds the
+     *   two fellow documents as AWAITING_UPLOAD; the fellowship starts in
+     *   AWAITING_DOCUMENTS and follows the normal upload/review flow.
+     * - PRESIGNED: uploads an already-signed contract and W-8BEN, both APPROVED
+     *   and reviewed by the admin; no unsigned-contract row is created and the
+     *   fellowship starts in DOCUMENTS_APPROVED, ready for start-contract.
      *
      * The caller is expected to have already set `application.status`,
      * `reviewedBy` and `reviewerRemarks`; this method persists them.
@@ -75,17 +104,23 @@ export class FellowshipDocumentsService {
     async provisionAcceptedApplication(
         application: FellowshipApplication,
         reviewer: User,
-        file: Express.Multer.File,
+        contract: AcceptedContract,
         kind: FellowshipKind = FellowshipKind.FELLOWSHIP,
     ): Promise<Fellowship> {
-        this.assertValidPdf(file);
+        // Content-level %PDF- check on every provided file, before we touch Drive.
+        if (contract.mode === AcceptContractMode.PRESIGNED) {
+            this.assertValidPdf(contract.signedContract);
+            this.assertValidPdf(contract.w8ben);
+        } else {
+            this.assertValidPdf(contract.unsignedContract);
+        }
 
-        // Run folder creation, the Drive upload and the row writes inside one
+        // Run folder creation, the Drive upload(s) and the row writes inside one
         // transaction, guarded by a pessimistic lock on the application row. Two
         // concurrent accepts of the same application serialize on the lock; the
         // loser re-reads a non-null driveFolderId and bails before creating
         // anything, so a folder is never orphaned. On any failure we best-effort
-        // delete the folder this attempt created.
+        // delete the folder this attempt created (which removes any files in it).
         let createdFolderId: string | null = null;
         try {
             return await this.dbTransactionService.execute(async (manager) => {
@@ -107,14 +142,111 @@ export class FellowshipDocumentsService {
                     this.drive.rootFolderId,
                 );
                 createdFolderId = folderId;
-                const unsignedFileId = await this.drive.uploadFile({
-                    parentId: folderId,
-                    name: this.documentFileName(
-                        FellowshipDocumentType.UNSIGNED_CONTRACT,
-                    ),
-                    mimeType: PDF_MIME_TYPE,
-                    body: Readable.from(file.buffer),
-                });
+
+                // Drive first: upload every contract document (and build the row
+                // specs) before any DB write, so a failed upload rolls back the
+                // whole transaction and the best-effort folder delete is the only
+                // cleanup needed.
+                let fellowshipStatus: FellowshipStatus;
+                let documents: FellowshipDocument[];
+
+                if (contract.mode === AcceptContractMode.PRESIGNED) {
+                    // Admin-provided, admin-approved: upload the signed contract
+                    // and the W-8BEN, mark both APPROVED, and skip the fellow's
+                    // upload/review cycle. Both fellow documents approved means the
+                    // fellowship lands directly in DOCUMENTS_APPROVED.
+                    const signedFileId = await this.drive.uploadFile({
+                        parentId: folderId,
+                        name: this.documentFileName(
+                            FellowshipDocumentType.SIGNED_CONTRACT,
+                        ),
+                        mimeType: PDF_MIME_TYPE,
+                        body: Readable.from(contract.signedContract.buffer),
+                    });
+                    const w8benFileId = await this.drive.uploadFile({
+                        parentId: folderId,
+                        name: this.documentFileName(
+                            FellowshipDocumentType.W8BEN,
+                        ),
+                        mimeType: PDF_MIME_TYPE,
+                        body: Readable.from(contract.w8ben.buffer),
+                    });
+
+                    fellowshipStatus = FellowshipStatus.DOCUMENTS_APPROVED;
+                    documents = [
+                        manager.create(FellowshipDocument, {
+                            application,
+                            type: FellowshipDocumentType.SIGNED_CONTRACT,
+                            status: FellowshipDocumentStatus.APPROVED,
+                            driveFileId: signedFileId,
+                            fileName: this.sanitizeFileName(
+                                contract.signedContract.originalname,
+                                this.documentFileName(
+                                    FellowshipDocumentType.SIGNED_CONTRACT,
+                                ),
+                            ),
+                            mimeType: PDF_MIME_TYPE,
+                            sizeBytes: contract.signedContract.size,
+                            uploadedBy: reviewer,
+                            reviewedBy: reviewer,
+                        }),
+                        manager.create(FellowshipDocument, {
+                            application,
+                            type: FellowshipDocumentType.W8BEN,
+                            status: FellowshipDocumentStatus.APPROVED,
+                            driveFileId: w8benFileId,
+                            fileName: this.sanitizeFileName(
+                                contract.w8ben.originalname,
+                                this.documentFileName(
+                                    FellowshipDocumentType.W8BEN,
+                                ),
+                            ),
+                            mimeType: PDF_MIME_TYPE,
+                            sizeBytes: contract.w8ben.size,
+                            uploadedBy: reviewer,
+                            reviewedBy: reviewer,
+                        }),
+                    ];
+                } else {
+                    // Standard flow: the admin uploads the Bitshala unsigned
+                    // contract; the fellow will upload the signed contract +
+                    // W-8BEN, which an admin then reviews.
+                    const unsignedFileId = await this.drive.uploadFile({
+                        parentId: folderId,
+                        name: this.documentFileName(
+                            FellowshipDocumentType.UNSIGNED_CONTRACT,
+                        ),
+                        mimeType: PDF_MIME_TYPE,
+                        body: Readable.from(contract.unsignedContract.buffer),
+                    });
+
+                    fellowshipStatus = FellowshipStatus.AWAITING_DOCUMENTS;
+                    documents = [
+                        manager.create(FellowshipDocument, {
+                            application,
+                            type: FellowshipDocumentType.UNSIGNED_CONTRACT,
+                            status: FellowshipDocumentStatus.APPROVED,
+                            driveFileId: unsignedFileId,
+                            fileName: this.documentFileName(
+                                FellowshipDocumentType.UNSIGNED_CONTRACT,
+                            ),
+                            mimeType: PDF_MIME_TYPE,
+                            sizeBytes: contract.unsignedContract.size,
+                            uploadedBy: reviewer,
+                            reviewedBy: reviewer,
+                        }),
+                        manager.create(FellowshipDocument, {
+                            application,
+                            type: FellowshipDocumentType.SIGNED_CONTRACT,
+                            status: FellowshipDocumentStatus.AWAITING_UPLOAD,
+                        }),
+                        manager.create(FellowshipDocument, {
+                            application,
+                            type: FellowshipDocumentType.W8BEN,
+                            status: FellowshipDocumentStatus.AWAITING_UPLOAD,
+                        }),
+                    ];
+                }
 
                 application.driveFolderId = folderId;
                 await manager.save(FellowshipApplication, application);
@@ -124,35 +256,9 @@ export class FellowshipDocumentsService {
                     kind,
                     user: application.applicant,
                     application,
-                    status: FellowshipStatus.AWAITING_DOCUMENTS,
+                    status: fellowshipStatus,
                 });
                 await manager.save(Fellowship, fellowship);
-
-                const documents = [
-                    manager.create(FellowshipDocument, {
-                        application,
-                        type: FellowshipDocumentType.UNSIGNED_CONTRACT,
-                        status: FellowshipDocumentStatus.APPROVED,
-                        driveFileId: unsignedFileId,
-                        fileName: this.documentFileName(
-                            FellowshipDocumentType.UNSIGNED_CONTRACT,
-                        ),
-                        mimeType: PDF_MIME_TYPE,
-                        sizeBytes: file.size,
-                        uploadedBy: reviewer,
-                        reviewedBy: reviewer,
-                    }),
-                    manager.create(FellowshipDocument, {
-                        application,
-                        type: FellowshipDocumentType.SIGNED_CONTRACT,
-                        status: FellowshipDocumentStatus.AWAITING_UPLOAD,
-                    }),
-                    manager.create(FellowshipDocument, {
-                        application,
-                        type: FellowshipDocumentType.W8BEN,
-                        status: FellowshipDocumentStatus.AWAITING_UPLOAD,
-                    }),
-                ];
                 await manager.save(FellowshipDocument, documents);
 
                 return fellowship;

--- a/src/mail/mail.enum.ts
+++ b/src/mail/mail.enum.ts
@@ -9,6 +9,7 @@ export enum MailTemplate {
     CohortCalendarUpdate = 'cohort-calendar-update',
     FellowshipApplicationReceived = 'fellowship-application-received',
     FellowshipApplicationAccepted = 'fellowship-application-accepted',
+    FellowshipApplicationAcceptedNoDocuments = 'fellowship-application-accepted-no-documents',
     FellowshipApplicationRejected = 'fellowship-application-rejected',
     FellowshipApplicationChangesRequested = 'fellowship-application-changes-requested',
     FellowshipDocumentRejected = 'fellowship-document-rejected',

--- a/src/mail/mail.interface.ts
+++ b/src/mail/mail.interface.ts
@@ -74,6 +74,14 @@ export interface FellowshipApplicationAcceptedContext {
     documentsUrl: string;
 }
 
+// Acceptance where the signed contract and W-8BEN were provided out of band by
+// the admin, so there is nothing for the fellow to upload — hence no
+// `documentsUrl`.
+export interface FellowshipApplicationAcceptedNoDocumentsContext {
+    userName: string;
+    fellowshipType: string;
+}
+
 export interface FellowshipApplicationRejectedContext {
     userName: string;
     fellowshipType: string;
@@ -123,6 +131,7 @@ export interface TemplateContextMap {
     [MailTemplate.CohortCalendarUpdate]: CohortCalendarUpdateContext;
     [MailTemplate.FellowshipApplicationReceived]: FellowshipApplicationReceivedContext;
     [MailTemplate.FellowshipApplicationAccepted]: FellowshipApplicationAcceptedContext;
+    [MailTemplate.FellowshipApplicationAcceptedNoDocuments]: FellowshipApplicationAcceptedNoDocumentsContext;
     [MailTemplate.FellowshipApplicationRejected]: FellowshipApplicationRejectedContext;
     [MailTemplate.FellowshipApplicationChangesRequested]: FellowshipApplicationChangesRequestedContext;
     [MailTemplate.FellowshipDocumentRejected]: FellowshipDocumentRejectedContext;

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -421,6 +421,30 @@ export class MailService implements OnModuleInit {
         });
     }
 
+    // Acceptance where the signed contract and W-8BEN were supplied out of band
+    // by the admin. Unlike the standard accepted email, there is nothing for the
+    // fellow to upload, so this omits the contract/W-8BEN steps and the documents
+    // deep link.
+    async sendFellowshipApplicationAcceptedNoDocumentsEmail(
+        userEmail: string,
+        userName: string,
+        fellowshipType: FellowshipType,
+    ): Promise<void> {
+        const displayType = this.getFellowshipTypeDisplayName(fellowshipType);
+        const subject = `Welcome to the Bitshala ${displayType} Fellowship`;
+
+        return this.sendTemplatedEmail({
+            to: userEmail,
+            cc: 'fellowship@bitshala.org',
+            subject,
+            template: MailTemplate.FellowshipApplicationAcceptedNoDocuments,
+            context: {
+                userName,
+                fellowshipType: displayType,
+            },
+        });
+    }
+
     async sendFellowshipDocumentRejectedEmail(
         userEmail: string,
         userName: string,


### PR DESCRIPTION
## Summary

Adds a way for admins to upload an already-signed contract + W-8BEN directly when accepting a fellowship application, skipping the fellow's sign → upload → review cycle. Useful when the contract was signed out of band.

This is a `contractMode` on the existing accept endpoint (`PATCH /fellowship-applications/:id/review`), which now takes named multipart file fields via `FileFieldsInterceptor`:

- **`contractMode=UNSIGNED`** (default, unchanged): upload the Bitshala unsigned contract as `file`; fellowship starts `AWAITING_DOCUMENTS` and the fellow uploads/gets reviewed as before.
- **`contractMode=PRESIGNED`** (new): upload `signedContract` + `w8ben`; both are stored **APPROVED** (uploaded and reviewed by the admin), **no `UNSIGNED_CONTRACT` row** is created, and the fellowship is provisioned straight to **`DOCUMENTS_APPROVED`** — immediately ready for `start-contract`. The applicant receives a new "accepted, no action needed" email instead of the upload-instructions one.

## What changed

- `AcceptContractMode` enum + optional `contractMode` on the review DTO.
- `provisionAcceptedApplication` now takes a discriminated `AcceptedContract` and branches on mode **inside the existing transaction** — same pessimistic lock, `driveFolderId` idempotency guard, all Drive uploads before any DB write, and best-effort folder cleanup on failure (now covering both files).
- Controller switches to `FileFieldsInterceptor` (`file`, `signedContract`, `w8ben`); the service validates which files are required per mode and picks the acceptance email.
- New `fellowship-application-accepted-no-documents` email (HTML + text templates, interface context, mail method).
- Tests for the review dispatch (required files, provisioning args, email selection) and a new documents-service spec for `provisionAcceptedApplication` (both modes, idempotency, cleanup-on-upload-failure).

**No DB migration** — the `SIGNED_CONTRACT` / `W8BEN` document types and `DOCUMENTS_APPROVED` status already exist.

## Usage

```
# Pre-signed (skip the flow)
curl -X PATCH .../fellowship-applications/<id>/review \
  -H 'Authorization: Bearer <admin>' \
  -F 'status=ACCEPTED' -F 'contractMode=PRESIGNED' \
  -F 'signedContract=@signed.pdf' -F 'w8ben=@w8ben.pdf'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)