### PR TITLE
fix: correct IST/UTC mislabeling in cohort calendar ICS feed

### DIFF
--- a/src/cohort-calendar/cohort-calendar.service.ts
+++ b/src/cohort-calendar/cohort-calendar.service.ts
@@ -105,7 +105,6 @@ export class CohortCalendarService {
         const calendar = ical({
             name: calendarName,
             method,
-            timezone: 'Asia/Kolkata',
             x: [
                 ['X-WR-CALNAME', calendarName],
                 ['REFRESH-INTERVAL', 'P1H'],
@@ -136,7 +135,6 @@ export class CohortCalendarService {
                 description,
                 location,
                 url: DISCORD_GENERAL_INVITE_URL,
-                timezone: 'Asia/Kolkata',
             });
 
             event.createAlarm({


### PR DESCRIPTION
## Summary
- Apple/Google Calendar subscribers saw cohort sessions ~5.5 hours early (UTC time labeled as IST).
- Root cause: `ical-generator`'s `timezone: 'Asia/Kolkata'` option does not convert the `Date` — it reads local wall-clock getters off the host process's own timezone (UTC on the server) and tags the result `TZID=Asia/Kolkata` with no conversion, so the UTC hour (`setUTCHours(14, 30, ...)`, i.e. 8:00 PM IST) was mislabeled as 2:30 PM IST.
- Fix: drop the `timezone` option on both the calendar and event; the `Date` objects already hold the correct UTC instant, so `ical-generator` now emits proper `Z`-suffixed UTC timestamps, which any calendar client converts correctly to the viewer's own timezone.

Verified locally by replicating the exact date-construction/`ical-generator` call:
- Before: `DTSTART;TZID=Asia/Kolkata:20260820T143000` (wrong — reads as 2:30 PM IST)
- After: `DTSTART:20260820T143000Z` (correct — converts to 8:00 PM IST everywhere)

## Test plan
- [ ] Subscribe to a cohort calendar feed in Apple Calendar and confirm session times show correctly in IST
- [ ] Confirm existing calendar invite emails still render correct times in mail clients