### PR TITLE
feat: public preview — anonymous access to cohorts, curriculum and leaderboards

### DIFF
--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -21,10 +21,26 @@ export class AuthGuard implements CanActivate {
             IS_PUBLIC_KEY,
             [context.getHandler(), context.getClass()],
         );
-        if (isPublic) return true;
-
         const request = context.switchToHttp().getRequest();
         const token = AuthGuard.extractTokenFromRequest(request);
+
+        // A public route is open to everyone, but it should still know who is
+        // asking when a usable token is present: routes like GET /cohorts serve
+        // a role-gated projection, and returning early here would hand signed-in
+        // members the anonymous view. A missing or invalid token simply means
+        // anonymous, so it is never an error on this path.
+        if (isPublic) {
+            if (token) {
+                try {
+                    request['user'] =
+                        await this.authService.getUserFromSession(token);
+                } catch {
+                    // Treat as anonymous; request.user stays unset.
+                }
+            }
+            return true;
+        }
+
         if (!token) {
             throw new UnauthorizedException();
         }

--- a/src/cohorts/cohort-access.util.ts
+++ b/src/cohorts/cohort-access.util.ts
@@ -1,24 +1,39 @@
 import { UserRole } from '@/common/enum';
 import { Link } from '@/entities/cohort.entity';
 
+// Who is asking. `null` is an anonymous (unauthenticated) viewer on a @Public()
+// route, where @GetUser() yields undefined.
+export type ViewerRole = UserRole | null;
+
 const ROLE_RANK: Record<UserRole, number> = {
     [UserRole.STUDENT]: 0,
     [UserRole.TEACHING_ASSISTANT]: 1,
     [UserRole.ADMIN]: 2,
 };
 
+// Anonymous ranks below every authenticated role.
+const ANONYMOUS_RANK = -1;
+
+// Deliberately no `?? 0` fallback: STUDENT *is* rank 0, so a fallback would
+// hand full student visibility to any role the table forgot. Record<UserRole,
+// number> makes the lookup exhaustive, so a new UserRole member is a compile
+// error here rather than a silent leak.
+function rankOf(role: ViewerRole): number {
+    return role === null ? ANONYMOUS_RANK : ROLE_RANK[role];
+}
+
 /** True if `role` is at least as privileged as `minRole`. */
-export function isAtLeastRole(role: UserRole, minRole: UserRole): boolean {
-    return (ROLE_RANK[role] ?? 0) >= (ROLE_RANK[minRole] ?? 0);
+export function isAtLeastRole(role: ViewerRole, minRole: UserRole): boolean {
+    return rankOf(role) >= ROLE_RANK[minRole];
 }
 
 /** Bonus questions are staff-only (TA/Admin). */
-export function canViewBonusQuestions(role: UserRole): boolean {
+export function canViewBonusQuestions(role: ViewerRole): boolean {
     return role === UserRole.TEACHING_ASSISTANT || role === UserRole.ADMIN;
 }
 
 /** Drop links the requesting role is not permitted to see. */
-export function filterLinksByRole(links: Link[], role: UserRole): Link[] {
+export function filterLinksByRole(links: Link[], role: ViewerRole): Link[] {
     return links.filter(
         (link) => !link.minRole || isAtLeastRole(role, link.minRole),
     );

--- a/src/cohorts/cohorts.controller.ts
+++ b/src/cohorts/cohorts.controller.ts
@@ -104,14 +104,26 @@ export class CohortsController {
         return this.cohortsService.listMyCohorts(user, query);
     }
 
+    @Public()
     @Get('attachments/:id/:filename')
-    @ApiOperation({ summary: 'Stream a cohort question attachment' })
+    @ApiOperation({
+        summary: 'Stream a cohort question attachment',
+        description:
+            'Readable without authentication for attachments referenced by a non-bonus question; bonus-question attachments stay staff-only.',
+    })
     async getAttachment(
         @Param('id', new ParseUUIDPipe()) id: string,
         @Param('filename') filename: string,
         @Res({ passthrough: true }) res: Response,
+        // undefined on an anonymous request — this route is @Public().
+        @GetUser() user: User | undefined,
     ): Promise<StreamableFile> {
-        return this.cohortsService.getAttachment(id, filename, res);
+        return this.cohortsService.getAttachment(
+            id,
+            filename,
+            res,
+            user?.role ?? null,
+        );
     }
 
     @Public()

--- a/src/cohorts/cohorts.controller.ts
+++ b/src/cohorts/cohorts.controller.ts
@@ -45,8 +45,13 @@ import { User } from '@/entities/user.entity';
 export class CohortsController {
     constructor(private readonly cohortsService: CohortsService) {}
 
+    @Public()
     @Get()
-    @ApiOperation({ summary: 'List cohorts with pagination' })
+    @ApiOperation({
+        summary: 'List cohorts with pagination',
+        description:
+            'Readable without authentication; the response is filtered down to public content for anonymous viewers.',
+    })
     @ApiQuery({
         name: 'page',
         type: 'number',
@@ -60,10 +65,11 @@ export class CohortsController {
         description: 'Number of items per page',
     })
     async listCohorts(
-        @GetUser() user: User,
+        // undefined on an anonymous request — this route is @Public().
+        @GetUser() user: User | undefined,
         @Query() query: PaginatedQueryDto,
     ): Promise<PaginatedDataDto<GetCohortResponseDto>> {
-        return this.cohortsService.listCohorts(query, user.role);
+        return this.cohortsService.listCohorts(query, user?.role ?? null);
     }
 
     @Public()
@@ -108,13 +114,19 @@ export class CohortsController {
         return this.cohortsService.getAttachment(id, filename, res);
     }
 
+    @Public()
     @Get(':id')
-    @ApiOperation({ summary: 'Get a cohort by ID' })
+    @ApiOperation({
+        summary: 'Get a cohort by ID',
+        description:
+            'Readable without authentication; the response is filtered down to public content for anonymous viewers.',
+    })
     async getCohort(
         @Param('id', new ParseUUIDPipe()) id: string,
-        @GetUser() user: User,
+        // undefined on an anonymous request — this route is @Public().
+        @GetUser() user: User | undefined,
     ): Promise<GetCohortResponseDto> {
-        return this.cohortsService.getCohort(id, user.role);
+        return this.cohortsService.getCohort(id, user?.role ?? null);
     }
 
     @Post()

--- a/src/cohorts/cohorts.response.dto.ts
+++ b/src/cohorts/cohorts.response.dto.ts
@@ -146,6 +146,7 @@ export class GetCohortResponseDto {
 }
 
 export class PublicCohortResponseDto {
+    id!: string;
     type!: string;
     season!: number;
     startDate!: string;
@@ -153,6 +154,7 @@ export class PublicCohortResponseDto {
     registrationDeadline!: string;
 
     constructor(obj: PublicCohortResponseDto) {
+        this.id = obj.id;
         this.type = obj.type;
         this.season = obj.season;
         this.startDate = obj.startDate;

--- a/src/cohorts/cohorts.response.dto.ts
+++ b/src/cohorts/cohorts.response.dto.ts
@@ -1,4 +1,4 @@
-import { CohortType, CohortWeekType, UserRole } from '@/common/enum';
+import { CohortType, CohortWeekType } from '@/common/enum';
 import { Cohort } from '@/entities/cohort.entity';
 import {
     Exercise,
@@ -9,6 +9,7 @@ import { getCohortFullName } from '@/common/cohort-display';
 import {
     canViewBonusQuestions,
     filterLinksByRole,
+    ViewerRole,
 } from '@/cohorts/cohort-access.util';
 
 export interface CohortLink {
@@ -81,8 +82,11 @@ export class GetCohortResponseDto {
     // gated DTO can never be constructed without it (a missed call site is a
     // compile error, not a silent leak). Arrays are deep-copied so the response
     // never aliases (and can never mutate) entity state.
-    static fromEntity(cohort: Cohort, role: UserRole): GetCohortResponseDto {
+    static fromEntity(cohort: Cohort, role: ViewerRole): GetCohortResponseDto {
         const canSeeBonus = canViewBonusQuestions(role);
+        // GitHub Classroom ids and invite links are join tokens, not content:
+        // anyone holding one can enrol. Withhold them from anonymous viewers.
+        const isAnonymous = role === null;
 
         return new GetCohortResponseDto({
             id: cohort.id,
@@ -93,7 +97,7 @@ export class GetCohortResponseDto {
             endDate: cohort.getEndDate().toISOString(),
             registrationDeadline: cohort.registrationDeadline.toISOString(),
             hasExercises: cohort.hasExercises,
-            classroomId: cohort.classroomId ?? null,
+            classroomId: isAnonymous ? null : (cohort.classroomId ?? null),
             // Links are filtered by role; minRole is dropped from the response.
             links: filterLinksByRole(cohort.links ?? [], role).map((link) => ({
                 label: link.label,
@@ -129,8 +133,12 @@ export class GetCohortResponseDto {
                           expectedOutput: [...week.exercise.expectedOutput],
                       }
                     : null,
-                classroomInviteLink: week.classroomInviteLink || null,
-                classroomAssignmentUrl: week.classroomAssignmentUrl ?? null,
+                classroomInviteLink: isAnonymous
+                    ? null
+                    : week.classroomInviteLink || null,
+                classroomAssignmentUrl: isAnonymous
+                    ? null
+                    : (week.classroomAssignmentUrl ?? null),
                 scheduledDate: week.scheduledDate.toISOString(),
             })),
         });

--- a/src/cohorts/cohorts.service.ts
+++ b/src/cohorts/cohorts.service.ts
@@ -41,7 +41,10 @@ import { TWENTY_FOUR_HOURS_MS } from '@/common/durations.constants';
 import { MailService } from '@/mail/mail.service';
 import { CohortsConfigService } from '@/cohorts/cohorts.config.service';
 import { CohortCalendarService } from '@/cohort-calendar/cohort-calendar.service';
-import { ViewerRole } from '@/cohorts/cohort-access.util';
+import {
+    canViewBonusQuestions,
+    ViewerRole,
+} from '@/cohorts/cohort-access.util';
 import { createReadStream, existsSync } from 'fs';
 import { join, basename } from 'path';
 import { lookup } from 'mime-types';
@@ -160,10 +163,11 @@ export class CohortsService {
         cohortId: string,
         filename: string,
         res: Response,
+        role: ViewerRole,
     ): Promise<StreamableFile> {
         const cohort = await this.cohortRepository.findOne({
             where: { id: cohortId },
-            select: ['type'],
+            relations: { weeks: true },
         });
 
         if (!cohort) {
@@ -176,6 +180,20 @@ export class CohortsService {
         const sanitized = basename(filename);
         if (sanitized !== filename || filename.includes('\0')) {
             throw new BadRequestException('Invalid filename.');
+        }
+
+        // This route resolves <cohort type>/<filename> straight off disk, so on
+        // its own it would serve bonus-question images — which are staff-only —
+        // to anyone holding the cohort id. Non-staff may only fetch a filename
+        // some non-bonus question actually references. 404 rather than 403, so
+        // the response does not confirm that a staff-only file exists.
+        const isCurriculumAttachment = cohort.weeks.some((week) =>
+            (week.questions ?? []).some((question) =>
+                (question.attachments ?? []).includes(sanitized),
+            ),
+        );
+        if (!isCurriculumAttachment && !canViewBonusQuestions(role)) {
+            throw new NotFoundException('Attachment not found.');
         }
 
         const dir = cohort.type.toLowerCase().replace(/_/g, '-');

--- a/src/cohorts/cohorts.service.ts
+++ b/src/cohorts/cohorts.service.ts
@@ -30,7 +30,7 @@ import { Attendance } from '@/entities/attendance.entity';
 import { ExerciseScore } from '@/entities/exercise-score.entity';
 import { DiscordClient } from '@/discord-client/discord.client';
 import { ConfigService } from '@nestjs/config';
-import { CohortType, CohortWeekType, UserRole } from '@/common/enum';
+import { CohortType, CohortWeekType } from '@/common/enum';
 import { CohortMembership } from '@/entities/cohort-membership.entity';
 import { CohortWaitlist } from '@/entities/cohort-waitlist.entity';
 import { Certificate } from '@/entities/certificate.entity';
@@ -41,6 +41,7 @@ import { TWENTY_FOUR_HOURS_MS } from '@/common/durations.constants';
 import { MailService } from '@/mail/mail.service';
 import { CohortsConfigService } from '@/cohorts/cohorts.config.service';
 import { CohortCalendarService } from '@/cohort-calendar/cohort-calendar.service';
+import { ViewerRole } from '@/cohorts/cohort-access.util';
 import { createReadStream, existsSync } from 'fs';
 import { join, basename } from 'path';
 import { lookup } from 'mime-types';
@@ -139,7 +140,7 @@ export class CohortsService {
 
     async getCohort(
         cohortId: string,
-        role: UserRole,
+        role: ViewerRole,
     ): Promise<GetCohortResponseDto> {
         const cohort: Cohort | null = await this.cohortRepository.findOne({
             where: { id: cohortId },
@@ -221,7 +222,7 @@ export class CohortsService {
 
     async listCohorts(
         query: PaginatedQueryDto,
-        role: UserRole,
+        role: ViewerRole,
     ): Promise<PaginatedDataDto<GetCohortResponseDto>> {
         const [cohorts, total]: [Cohort[], number] =
             await this.cohortRepository.findAndCount({

--- a/src/cohorts/cohorts.service.ts
+++ b/src/cohorts/cohorts.service.ts
@@ -227,6 +227,7 @@ export class CohortsService {
                 .map(
                     (cohort) =>
                         new PublicCohortResponseDto({
+                            id: cohort.id,
                             type: cohort.type,
                             season: cohort.season,
                             startDate: cohort.startDate.toISOString(),

--- a/src/scores/scores.controller.ts
+++ b/src/scores/scores.controller.ts
@@ -25,9 +25,11 @@ import {
     LeaderboardEntryDto,
     ListScoresForCohortAndWeekResponseDto,
     PublicLeaderboardEntryDto,
+    StudentLeaderboardEntryDto,
 } from '@/scores/scores.response.dto';
 import { Roles } from '@/auth/roles.decorator';
 import { Public } from '@/auth/public-route.decorator';
+import { isAtLeastRole } from '@/cohorts/cohort-access.util';
 import { UserRole } from '@/common/enum';
 import {
     AssignGroupsRequestDto,
@@ -47,6 +49,27 @@ function ApiCrossCohortPerformanceResponse() {
                 type: 'object',
                 additionalProperties: {
                     $ref: getSchemaPath(CrossCohortPerformanceEntryDto),
+                },
+            },
+        }),
+    );
+}
+
+// The leaderboard row shape depends on the caller's role, so the response is
+// documented as a union rather than a single model.
+function ApiLeaderboardResponse() {
+    return applyDecorators(
+        ApiExtraModels(LeaderboardEntryDto, StudentLeaderboardEntryDto),
+        ApiOkResponse({
+            description:
+                'LeaderboardEntryDto[] for TA/Admin, StudentLeaderboardEntryDto[] for students',
+            schema: {
+                type: 'array',
+                items: {
+                    oneOf: [
+                        { $ref: getSchemaPath(LeaderboardEntryDto) },
+                        { $ref: getSchemaPath(StudentLeaderboardEntryDto) },
+                    ],
                 },
             },
         }),
@@ -76,11 +99,21 @@ export class ScoresController {
     @ApiOperation({
         summary:
             'Get aggregated scores for a cohort across all weeks for leaderboard',
+        description:
+            'Every row carries the full score and attendance breakdown. Staff additionally see member identity (real name, Discord global name); students see the Discord handle only.',
     })
+    @ApiLeaderboardResponse()
+    @Roles(UserRole.STUDENT, UserRole.TEACHING_ASSISTANT, UserRole.ADMIN)
     async getCohortLeaderboard(
         @Param('cohortId', new ParseUUIDPipe()) cohortId: string,
-    ): Promise<LeaderboardEntryDto[]> {
-        return this.scoresService.getCohortLeaderboard(cohortId);
+        @GetUser() user: User,
+    ): Promise<LeaderboardEntryDto[] | StudentLeaderboardEntryDto[]> {
+        // Members' real names are staff-only. Students get the same scores and
+        // attendance figures over a Discord-handle-only identity, so the
+        // leaderboard UI keeps working without leaking who anyone is.
+        return isAtLeastRole(user.role, UserRole.TEACHING_ASSISTANT)
+            ? this.scoresService.getCohortLeaderboard(cohortId)
+            : this.scoresService.getStudentCohortLeaderboard(cohortId);
     }
 
     @Public()

--- a/src/scores/scores.controller.ts
+++ b/src/scores/scores.controller.ts
@@ -24,8 +24,10 @@ import {
     GetUsersScoresResponseDto,
     LeaderboardEntryDto,
     ListScoresForCohortAndWeekResponseDto,
+    PublicLeaderboardEntryDto,
 } from '@/scores/scores.response.dto';
 import { Roles } from '@/auth/roles.decorator';
+import { Public } from '@/auth/public-route.decorator';
 import { UserRole } from '@/common/enum';
 import {
     AssignGroupsRequestDto,
@@ -79,6 +81,15 @@ export class ScoresController {
         @Param('cohortId', new ParseUUIDPipe()) cohortId: string,
     ): Promise<LeaderboardEntryDto[]> {
         return this.scoresService.getCohortLeaderboard(cohortId);
+    }
+
+    @Public()
+    @Get('cohort/:cohortId/leaderboard/public')
+    @ApiOperation({ summary: 'Public cohort leaderboard (no PII)' })
+    async getPublicCohortLeaderboard(
+        @Param('cohortId', new ParseUUIDPipe()) cohortId: string,
+    ): Promise<PublicLeaderboardEntryDto[]> {
+        return this.scoresService.getPublicCohortLeaderboard(cohortId);
     }
 
     @Patch('user/:userId/cohort/:cohortId/week/:weekId')

--- a/src/scores/scores.response.dto.ts
+++ b/src/scores/scores.response.dto.ts
@@ -335,6 +335,53 @@ export class PublicLeaderboardEntryDto {
     }
 }
 
+/**
+ * A leaderboard row as served to students: the full score and attendance
+ * breakdown, with member identity reduced to the Discord handle.
+ *
+ * Hand-written projection for the same reason as PublicLeaderboardEntryDto — and
+ * here it is load-bearing rather than merely defensive. These rows are built
+ * from a LeaderboardEntryDto, which carries the member's real name, so an
+ * Object.assign or a spread would copy that straight through. Naming every field
+ * is what keeps it out.
+ *
+ * userId is retained so the client can highlight the signed-in member's own row.
+ */
+export class StudentLeaderboardEntryDto {
+    userId!: string;
+    discordUsername!: string;
+    groupDiscussionTotalScore!: number;
+    groupDiscussionMaxTotalScore!: number;
+    exerciseTotalScore!: number;
+    exerciseMaxTotalScore!: number;
+    attendanceTotalScore!: number;
+    attendanceMaxTotalScore!: number;
+    totalScore!: number;
+    maxTotalScore!: number;
+    totalAttendance!: number;
+    maxAttendance!: number;
+    totalGroupDiscussionAttendance!: number;
+    maxGroupDiscussionAttendance!: number;
+
+    constructor(obj: StudentLeaderboardEntryDto) {
+        this.userId = obj.userId;
+        this.discordUsername = obj.discordUsername;
+        this.groupDiscussionTotalScore = obj.groupDiscussionTotalScore;
+        this.groupDiscussionMaxTotalScore = obj.groupDiscussionMaxTotalScore;
+        this.exerciseTotalScore = obj.exerciseTotalScore;
+        this.exerciseMaxTotalScore = obj.exerciseMaxTotalScore;
+        this.attendanceTotalScore = obj.attendanceTotalScore;
+        this.attendanceMaxTotalScore = obj.attendanceMaxTotalScore;
+        this.totalScore = obj.totalScore;
+        this.maxTotalScore = obj.maxTotalScore;
+        this.totalAttendance = obj.totalAttendance;
+        this.maxAttendance = obj.maxAttendance;
+        this.totalGroupDiscussionAttendance =
+            obj.totalGroupDiscussionAttendance;
+        this.maxGroupDiscussionAttendance = obj.maxGroupDiscussionAttendance;
+    }
+}
+
 export class ListScoresForCohortAndWeekResponseDto {
     scores!: UsersWeekScoreResponseDto[];
 

--- a/src/scores/scores.response.dto.ts
+++ b/src/scores/scores.response.dto.ts
@@ -310,6 +310,31 @@ export class LeaderboardEntryDto {
     }
 }
 
+/**
+ * A leaderboard row as served to anonymous viewers: Discord handle, rank and
+ * total score only.
+ *
+ * Deliberately a hand-written projection rather than an Omit<> of, or a spread
+ * from, LeaderboardEntryDto — that DTO carries the member's real name, Discord
+ * global name, user id, attendance counts and a per-component score breakdown.
+ * Listing the four permitted fields explicitly means a field added there later
+ * cannot surface here by default: leaking a new one has to be an act of
+ * commission. The constructor copies field by field for the same reason.
+ */
+export class PublicLeaderboardEntryDto {
+    rank!: number;
+    discordUsername!: string;
+    totalScore!: number;
+    maxTotalScore!: number;
+
+    constructor(obj: PublicLeaderboardEntryDto) {
+        this.rank = obj.rank;
+        this.discordUsername = obj.discordUsername;
+        this.totalScore = obj.totalScore;
+        this.maxTotalScore = obj.maxTotalScore;
+    }
+}
+
 export class ListScoresForCohortAndWeekResponseDto {
     scores!: UsersWeekScoreResponseDto[];
 

--- a/src/scores/scores.service.ts
+++ b/src/scores/scores.service.ts
@@ -11,6 +11,7 @@ import {
     GetUsersScoresResponseDto,
     LeaderboardEntryDto,
     ListScoresForCohortAndWeekResponseDto,
+    PublicLeaderboardEntryDto,
     UsersWeekScoreResponseDto,
     WeeklyScore,
 } from '@/scores/scores.response.dto';
@@ -634,5 +635,27 @@ export class ScoresService {
                     return b.exerciseTotalScore - a.exerciseTotalScore;
                 return b.totalScore - a.totalScore;
             });
+    }
+
+    // Projects the leaderboard down to what an anonymous viewer may see.
+    // Ranks come from the position in the already-sorted authenticated result,
+    // so the public ordering matches the real one and the client never needs
+    // the raw component scores to derive it. Note that ordering is primarily by
+    // exercise score (see docs/leaderboard-algorithm.md), so a lower totalScore
+    // can legitimately outrank a higher one here.
+    async getPublicCohortLeaderboard(
+        cohortId: string,
+    ): Promise<PublicLeaderboardEntryDto[]> {
+        const leaderboard = await this.getCohortLeaderboard(cohortId);
+
+        return leaderboard.map(
+            (entry, index) =>
+                new PublicLeaderboardEntryDto({
+                    rank: index + 1,
+                    discordUsername: entry.discordUsername,
+                    totalScore: entry.totalScore,
+                    maxTotalScore: entry.maxTotalScore,
+                }),
+        );
     }
 }

--- a/src/scores/scores.service.ts
+++ b/src/scores/scores.service.ts
@@ -12,6 +12,7 @@ import {
     LeaderboardEntryDto,
     ListScoresForCohortAndWeekResponseDto,
     PublicLeaderboardEntryDto,
+    StudentLeaderboardEntryDto,
     UsersWeekScoreResponseDto,
     WeeklyScore,
 } from '@/scores/scores.response.dto';
@@ -635,6 +636,39 @@ export class ScoresService {
                     return b.exerciseTotalScore - a.exerciseTotalScore;
                 return b.totalScore - a.totalScore;
             });
+    }
+
+    // Projects the leaderboard down to what a student may see: every score and
+    // attendance figure the authenticated view has, minus the member identity
+    // fields (real name, Discord global name). Ordering is untouched, so the
+    // client can keep deriving rank from position as it does today.
+    async getStudentCohortLeaderboard(
+        cohortId: string,
+    ): Promise<StudentLeaderboardEntryDto[]> {
+        const leaderboard = await this.getCohortLeaderboard(cohortId);
+
+        return leaderboard.map(
+            (entry) =>
+                new StudentLeaderboardEntryDto({
+                    userId: entry.userId,
+                    discordUsername: entry.discordUsername,
+                    groupDiscussionTotalScore: entry.groupDiscussionTotalScore,
+                    groupDiscussionMaxTotalScore:
+                        entry.groupDiscussionMaxTotalScore,
+                    exerciseTotalScore: entry.exerciseTotalScore,
+                    exerciseMaxTotalScore: entry.exerciseMaxTotalScore,
+                    attendanceTotalScore: entry.attendanceTotalScore,
+                    attendanceMaxTotalScore: entry.attendanceMaxTotalScore,
+                    totalScore: entry.totalScore,
+                    maxTotalScore: entry.maxTotalScore,
+                    totalAttendance: entry.totalAttendance,
+                    maxAttendance: entry.maxAttendance,
+                    totalGroupDiscussionAttendance:
+                        entry.totalGroupDiscussionAttendance,
+                    maxGroupDiscussionAttendance:
+                        entry.maxGroupDiscussionAttendance,
+                }),
+        );
     }
 
     // Projects the leaderboard down to what an anonymous viewer may see.


### PR DESCRIPTION
Backend half of the public-preview work. Makes a curated slice of the portal readable without
logging in — cohort catalog, week-by-week curriculum, and per-cohort leaderboards — without
leaking PII or staff-only content.

Companion to the `portal-frontend` public-preview work. **Land in step with the frontend**, not
ahead of it (see Breaking changes).

## The core problem

The app has only ever had three authenticated roles, and this introduces a fourth, *less*
privileged tier: anonymous. The existing fallback made that dangerous —

```ts
return (ROLE_RANK[role] ?? 0) >= (ROLE_RANK[minRole] ?? 0);
```

`STUDENT` **is** rank `0`, so passing `null` for an anonymous viewer would have resolved to
full student-level visibility of every `minRole`-tagged link. The first commit replaces the
fallback with an explicit `ViewerRole = UserRole | null`, an anonymous rank of `-1`, and an
exhaustive lookup — a new `UserRole` member is now a compile error rather than a silent leak.

## Commits

| Commit | Change |
|---|---|
| `d350cc1` | anonymous tier in the role filters |
| `d577cde` | `@Public()` on `GET /cohorts` + `/cohorts/:id`; classroom join tokens nulled for anonymous |
| `aa8c2b0` | public attachment route, bonus-question images kept staff-only |
| `ba4bdac` | `id` added to `GET /cohorts/available` so the landing page can deep-link |
| `997e63d` | new `GET /scores/cohort/:id/leaderboard/public` |
| `15ddb4e` | real names removed from the student leaderboard |
| `736991e` | public routes now identify the caller when a token is present |

## Two things worth reviewer attention

**The attachment route needed a gate, not just `@Public()`.** `getAttachment` resolves
`<cohort type>/<filename>` straight off disk and never checks which question owns the file —
and today *every* attachment in the repo is referenced by a `bonusQuestion`, i.e. staff-only.
A plain `@Public()` would have made all of them anonymously fetchable. Non-staff can now only
fetch filenames referenced by a non-bonus question; missing permission returns 404 rather than
403 so the response doesn't confirm a staff-only file exists.

**`736991e` fixes a bug introduced by `d577cde`.** `AuthGuard` returned `true` for `@Public()`
routes *before* populating `request.user`, so `@GetUser()` was `undefined` for every caller
regardless of token. Harmless while public routes ignored the user — but once `/cohorts` served
a role-gated projection it meant signed-in students and staff got the anonymous view: no bonus
questions, no classroom links. Public routes now resolve the session when a token is present and
treat a missing or invalid one as anonymous rather than an error. Gated routes are untouched.

## Breaking changes

**Student leaderboard identity.** `GET /scores/cohort/:cohortId/leaderboard` still requires auth,
but its shape now depends on role. Staff responses are unchanged (all 17 fields). Student rows
drop `name`, `displayName` and `discordGlobalName`, keeping `userId` and `discordUsername`.

Note `displayName` was a getter over `name || discordGlobalName || discordUserName`, so it *was*
the real name whenever one was set — dropping `name` alone would have left the leak open.

Every score and attendance figure students see today is preserved (attendance, total, exercise,
group discussion), so only the identity column changes. The frontend must switch that column from
`displayName` to `discordUsername` or it will render blanks. Students will see Discord handles
where they previously saw real names — intended, but a visible product change.

Ordering is identical across all three tiers, so anything deriving rank from array position keeps
working.

## Deferred

Public cohort metrics (`GET /cohorts/metrics`) is **not** in this PR — it depends on #90, still
open. Once that merges it is a one-line `@Roles(TA, ADMIN)` → `@Public()` swap on
`getAllCohortsMetrics`. Until then `/cohort-metrics` must stay behind login: it currently computes
those numbers in the browser by fanning out over the leaderboard, which would ship every student's
real name to anonymous browsers.

## Known risk, unchanged

Throttling is 5 requests/sec **per IP**, globally — `app.module.ts` falls through to its defaults
because no `throttler.*` config key exists anywhere. That was survivable when every caller was a
logged-in individual; anonymous visitors behind NAT, corporate proxies and mobile carriers share
an IP, so one visitor's burst can 429 another. Left as-is by decision; the frontend is expected to
avoid fan-out on public pages. Worth watching after launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)